### PR TITLE
Fix keyword index generation for qch

### DIFF
--- a/index2devhelp.py
+++ b/index2devhelp.py
@@ -61,7 +61,7 @@ class Index2Devhelp(IndexTransform):
         global out_f, rel_link
         out_f.write('<keyword type="' + xml_escape(self.get_mark(el))
                     + '" name="' + xml_escape(full_name)
-                    + '" link="' + xml_escape(rel_link) + '"/>\n')
+                    + '" link="' + xml_escape(full_link) + '"/>\n')
         IndexTransform.process_item_hook(self, el, full_name, full_link)
 
 out_f.write('<?xml version="1.0"?>\n'


### PR DESCRIPTION
Previously due this bug all C++ context searches were pointing to "cpp" index
page, C searched to "c" index page. This fix brings back context search (F1)
functionality that was broken for last 2014 qch releases.

This bug was introduced by 9b020fd rewrite of index generation from XSL to Python.
