### PR TITLE
preprocess.py: Don't break links with anchors

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -151,6 +151,7 @@ def rlink_fix(match):
     target = re.sub('(\.php|\.css)\?.*', '\\1', target)
     target = urllib.parse.quote(target)
     target = xml_escape(target)
+    target = target.replace('%23', '#');
     return pre + target + post
 
 # clean the html files


### PR DESCRIPTION
There's an issue currently that causes preprocess.py to break links that contain in-page anchors (e.g. `page.html#Some_Anchor`).

For example, if you open `output/reference/en/cpp/types/is_trivial.html` and look at the link in the description called `trivial default constructor`, it points to `default_constructor.html%23Trivial_default_constructor` instead of `default_constructor.html#Trivial_default_constructor` (notice the percent escaping of the `#`).