### PR TITLE
QCH book for C reference; process Windows filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ doc_html: output/reference
 
 doc_devhelp: output/cppreference-doc-en-c.devhelp2 output/cppreference-doc-en-cpp.devhelp2
 
-doc_qch: output/cppreference-doc-en-cpp.qch
+doc_qch: output/cppreference-doc-en-c.qch output/cppreference-doc-en-cpp.qch
 
 doc_doxygen: output/cppreference-doxygen-web.tag.xml output/cppreference-doxygen-local.tag.xml
 
@@ -169,6 +169,32 @@ output/cppreference-doc-en-cpp.devhelp2:	\
 		"output/cppreference-doc-en-cpp.devhelp2"
 
 #build the .qch (QT help) file
+output/cppreference-doc-en-c.qch: output/qch-help-project-c.xml
+	#qhelpgenerator only works if the project file is in the same directory as the documentation
+	cp "output/qch-help-project-c.xml" "output/reference/qch.xml"
+
+	pushd "output/reference" > /dev/null; \
+	$(qhelpgenerator) "qch.xml" -o "../cppreference-doc-en-c.qch"; \
+	popd > /dev/null
+
+	rm -f "output/reference/qch.xml"
+
+output/qch-help-project-c.xml: output/cppreference-doc-en-c.devhelp2
+	#build the file list
+	echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?><files>" > "output/qch-files.xml"
+
+	pushd "output/reference" > /dev/null; \
+	find . -type f -not -iname "*.ttf" \
+		-exec echo "<file>"'{}'"</file>" \; | LC_ALL=C sort >> "../qch-files.xml" ; \
+	popd > /dev/null
+
+	echo "</files>" >> "output/qch-files.xml"
+
+	#create the project (copies the file list)
+	./devhelp2qch.py --src=output/cppreference-doc-en-c.devhelp2 \
+		--dst=output/qch-help-project-c.xml \
+		--virtual_folder=c --file_list=output/qch-files.xml
+
 output/cppreference-doc-en-cpp.qch: output/qch-help-project-cpp.xml
 	#qhelpgenerator only works if the project file is in the same directory as the documentation
 	cp "output/qch-help-project-cpp.xml" "output/reference/qch.xml"

--- a/preprocess.py
+++ b/preprocess.py
@@ -117,7 +117,7 @@ def find_files_to_be_renamed(root):
                                 # modify some of them later in the pipeline
 
     for dir, dirnames, filenames in os.walk(root):
-        filenames_loader = set(fnmatch.filter(filenames, 'load.php[?]*'))
+        filenames_loader = set(fnmatch.filter(filenames, 'load.php[?_]*'))
         # match any filenames with '?"*' characters
         filenames_rename = set(fnmatch.filter(filenames, '*[?"*]*'))
 
@@ -162,6 +162,12 @@ def find_html_files(root):
             html_files.append(os.path.join(dir, filename))
     return html_files
 
+def fix_non_windows_symbols(text):
+    windows_non_filename_symbols = [':', '\"', '?', '*', '<', '>', '\\', '|']
+    for sym in windows_non_filename_symbols:
+        text = text.replace(sym, '_')
+    return text
+
 def fix_relative_link(rename_map, target, file, root):
     external_link_patterns = [
         'http://',
@@ -178,8 +184,10 @@ def fix_relative_link(rename_map, target, file, root):
                 return target
 
     target = urllib.parse.unquote(target)
+    target = fix_non_windows_symbols(target)
     for dir,fn,new_fn in rename_map:
-        target = target.replace(fn, new_fn)
+        fn_fix = fix_non_windows_symbols(fn)
+        target = target.replace(fn_fix, new_fn)
     target = target.replace('../../upload.cppreference.com/mwiki/','../common/')
     target = target.replace('../mwiki/','../common/')
     target = re.sub('(\.php|\.css)\?.*', '\\1', target)


### PR DESCRIPTION
- added target for C reference in QCH format
- added fixes for Windows filenames

Here I added a prerequisite for `doc_qch` to generate a file for **C reference** block.

Also I used the script on Windows, with MSYS console, but when I unpack a reference zip it replaces non-Windows symbols with `_` character so the script failed to map resources to the pages.

So this modification handles `_` symbols in filenames and replaces corresponding resource paths (`link href`) with correct values.

Not tested on Linux, but the **line 189** of the **preprocess.py** should process the Linux paths accordingly.

Maybe you could create a Windows branch for this change or add an input argument for this OS.

Thanks.