### PR TITLE
Preprocess: handle Ranges placeholders and avoid unnecessary regex use

### DIFF
--- a/commands/preprocess.py
+++ b/commands/preprocess.py
@@ -90,14 +90,14 @@ def add_file_to_rename_map(rename_map, dir, fn, new_fn):
 # Converts complex URL to resources supplied by MediaWiki loader to a simplified
 # name
 def convert_loader_name(fn):
-    if re.search("modules=site&only=scripts", fn):
+    if "modules=site&only=scripts" in fn:
         return "site_scripts.js"
-    elif re.search("modules=site&only=styles", fn):
+    elif "modules=site&only=styles" in fn:
         return "site_modules.css"
+    elif "modules=startup&only=scripts" in fn:
+        return "startup_scripts.js"
     elif re.search("modules=skins.*&only=scripts", fn):
         return "skin_scripts.js"
-    elif re.search("modules=startup&only=scripts", fn):
-        return "startup_scripts.js"
     elif re.search("modules=.*ext.*&only=styles", fn):
         return "ext.css"
     else:
@@ -133,8 +133,8 @@ def find_files_to_be_renamed(root):
     for dir,orig_fn in files_rename:
         fn = orig_fn
         fn = re.sub(r'\?.*', '', fn)
-        fn = re.sub('"', '_q_', fn)
-        fn = re.sub(r'\*', '_star_', fn)
+        fn = fn.replace('"', '_q_')
+        fn = fn.replace('*', '_star_')
         add_file_to_rename_map(rename_map, dir, orig_fn, fn)
 
     # map loader names to more recognizable names

--- a/commands/preprocess.py
+++ b/commands/preprocess.py
@@ -132,9 +132,9 @@ def find_files_to_be_renamed(root):
 
     for dir,orig_fn in files_rename:
         fn = orig_fn
-        fn = re.sub('\?.*', '', fn)
+        fn = re.sub(r'\?.*', '', fn)
         fn = re.sub('"', '_q_', fn)
-        fn = re.sub('\*', '_star_', fn)
+        fn = re.sub(r'\*', '_star_', fn)
         add_file_to_rename_map(rename_map, dir, orig_fn, fn)
 
     # map loader names to more recognizable names
@@ -164,7 +164,7 @@ def find_html_files(root):
     return html_files
 
 def is_loader_link(target):
-    if re.match('https?://[a-z]+\.cppreference\.com/mwiki/load\.php', target):
+    if re.match(r'https?://[a-z]+\.cppreference\.com/mwiki/load\.php', target):
         return True
     return False
 
@@ -212,7 +212,7 @@ def trasform_relative_link(rename_map, target):
         target = target.replace(fn, new_fn)
     target = target.replace('../../upload.cppreference.com/mwiki/','../common/')
     target = target.replace('../mwiki/','../common/')
-    target = re.sub('(\.php|\.css)\?.*', '\\1', target)
+    target = re.sub(r'(\.php|\.css)\?.*', r'\1', target)
     target = urllib.parse.quote(target)
     target = target.replace('%23', '#')
     return target

--- a/commands/preprocess.py
+++ b/commands/preprocess.py
@@ -179,6 +179,9 @@ def is_ranges_placeholder(target):
     return False
 
 def transform_ranges_placeholder(target, file, root):
+    # Placeholder link replacement is implemented in the MediaWiki site JS at
+    # https://en.cppreference.com/w/MediaWiki:Common.js
+
     ranges = 'cpp/experimental/ranges' in file
     repl = (r'\1/cpp/experimental/ranges/\2' if ranges else r'\1/cpp/\2')
 

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -102,6 +102,9 @@ class TestIsExternalLink(unittest.TestCase):
         self.assertEqual(False, is_external_link(' http://a'))
 
 class TestPlaceholderLinks(unittest.TestCase):
+    # Placeholder link replacement is implemented in the MediaWiki site JS at
+    # https://en.cppreference.com/w/MediaWiki:Common.js
+
     def test_is_ranges_placeholder(self):
         match = [
             'http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -101,4 +101,95 @@ class TestIsExternalLink(unittest.TestCase):
         self.assertEqual(False, is_external_link('ahttp://a'))
         self.assertEqual(False, is_external_link(' http://a'))
 
+class TestPlaceholderLinks(unittest.TestCase):
+    def test_is_ranges_placeholder(self):
+        match = [
+            'http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+            'http://en.cppreference.com/w/cpp/ranges-placeholder/iterator/Incrementable',
+            'http://en.cppreference.com/w/cpp/ranges-algorithm-placeholder/all_any_none_of',
+            'http://en.cppreference.com/w/cpp/ranges-iterator-placeholder/dangling',
+            'http://en.cppreference.com/w/cpp/ranges-utility-placeholder/swap',
+        ]
+        for target in match:
+            self.assertTrue(is_ranges_placeholder(target),
+                msg="Should match '{}'".format(target))
 
+            target = target.replace("http://", "https://")
+            self.assertTrue(is_ranges_placeholder(target),
+                msg="Should match '{}'".format(target))
+
+        nomatch = [
+            'http://en.cppreference.com/w/cpp/ranges--placeholder/swap',
+            'https://en.cppreference.com/w/cpp/ranges--placeholder/swap',
+            'http://www.mediawiki.org/',
+            'http://en.cppreference.com/w/Cppreference:About',
+            'http://en.wikipedia.org/wiki/Normal_distribution',
+            'https://www.mediawiki.org/',
+            'https://en.cppreference.com/w/Cppreference:About',
+            'https://en.wikipedia.org/wiki/Normal_distribution',
+            'w/cpp.html',
+            'w/cpp/language/expressions.html',
+            '../utility/functional/is_placeholder.html',
+            'utility/functional/placeholders.html',
+            'w/cpp/experimental/ranges.html',
+        ]
+        for target in nomatch:
+            self.assertFalse(is_ranges_placeholder(target),
+                msg="Should not match '{}'".format(target))
+
+    def test_transform_ranges_placeholder(self):
+        entries = [
+            # (target, file, expected)
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/concepts/ConvertibleTo.html',
+             'Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/concepts/long/path/ConvertibleTo.html',
+             '../../Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/other/path/ConvertibleTo.html',
+             '../../concepts/Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-algorithm-placeholder/all_any_none_of',
+             'output/reference/en/cpp/concepts/ConvertibleTo.html',
+             '../algorithm/ranges/all_any_none_of.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-algorithm-placeholder/all_any_none_of',
+             'output/reference/en/cpp/algorithm/ConvertibleTo.html',
+             'ranges/all_any_none_of.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/experimental/ranges/concepts/View.html',
+             'Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/experimental/ranges/View.html',
+             'concepts/Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-placeholder/concepts/Assignable',
+             'output/reference/en/cpp/experimental/ranges/range/View.html',
+             '../concepts/Assignable.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-algorithm-placeholder/all_any_none_of',
+             'output/reference/en/cpp/experimental/ranges/View.html',
+             'algorithm/all_any_none_of.html'),
+
+            ('http://en.cppreference.com/w/cpp/ranges-algorithm-placeholder/all_any_none_of',
+             'output/reference/en/cpp/experimental/ranges/range/View.html',
+             '../algorithm/all_any_none_of.html'),
+        ]
+
+        # transform_ranges_placeholder(target, file, root)
+        #  target: the placeholder link
+        #  file:   path of the file that contains the link
+        #  root:   path to the site root (where '/' should link to)
+        root = "output/reference"
+        for target, file, expected in entries:
+            self.assertEqual(expected, transform_ranges_placeholder(target, file, root),
+                msg="target='{}', file='{}', root='{}'".format(target, file, root))
+
+            target = target.replace('http://', 'https://')
+            self.assertEqual(expected, transform_ranges_placeholder(target, file, root),
+                msg="target='{}', file='{}', root='{}'".format(target, file, root))


### PR DESCRIPTION
This handles the new Ranges placeholder links, which are replaced by JS on the site but remain absolute when downloaded (because they result in a 404 status) and replaces them by proper relative links during HTML preprocessing.

There's also some small changes to regular expression use: use raw string literals for regex strings, and avoid unnecessary regex use which can be replaced by simple string operations.