### PR TITLE
Remove unnecessary copy step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,6 @@ output/reference:
 	./preprocess.py --src reference --dst output/reference
 
 output/reference_cssless: output/reference
-	cp -a output/reference output/reference_cssless
 	./preprocess_qch.py --src output/reference --dst output/reference_cssless
 
 # create indexes for the wiki


### PR DESCRIPTION
This removes an unnecessary copy of the whole output HTML that is immediately deleted by the QCH preprocessing script.