### PR TITLE
Performance improvements for QCH preprocessing

### DIFF
--- a/commands/preprocess_cssless.py
+++ b/commands/preprocess_cssless.py
@@ -70,6 +70,7 @@ def preprocess_html_merge_css(root, src_path):
         premailer = Premailer(root, base_url=src_path,
                               disable_link_rewrites=True,
                               remove_classes=True,
+                              disable_validation=True,
                               drop_style_tags=True)
         root = premailer.transform().getroot()
 

--- a/commands/preprocess_cssless.py
+++ b/commands/preprocess_cssless.py
@@ -20,7 +20,6 @@ import cssutils
 from lxml import html
 from lxml import etree
 from io import StringIO
-from lxml.etree import strip_elements
 import logging
 import re
 import os
@@ -35,7 +34,6 @@ def preprocess_html_merge_cssless(src_path, dst_path):
         root = etree.fromstring(stripped, parser)
 
     output = preprocess_html_merge_css(root, src_path)
-    strip_style_tags(root)
     remove_display_none(root)
     convert_span_tables_to_tr_td(root)
     convert_inline_block_elements_to_table(root)
@@ -70,13 +68,12 @@ def preprocess_html_merge_css(root, src_path):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         premailer = Premailer(root, base_url=src_path,
-                              disable_link_rewrites=True, remove_classes=True)
+                              disable_link_rewrites=True,
+                              remove_classes=True,
+                              drop_style_tags=True)
         root = premailer.transform().getroot()
 
     return output.getvalue()
-
-def strip_style_tags(root):
-    strip_elements(root, 'style')
 
 def needs_td_wrapper(element):
     # element has table:row

--- a/commands/preprocess_cssless.py
+++ b/commands/preprocess_cssless.py
@@ -22,6 +22,7 @@ from lxml import etree
 from io import StringIO
 from lxml.etree import strip_elements
 import logging
+import re
 import os
 import warnings
 import io
@@ -82,36 +83,58 @@ def needs_td_wrapper(element):
     if len(element.getchildren()) == 0:
         return True
     for el in element.getchildren():
-        if has_css_property_value(el, 'display', 'table-row') or \
-                has_css_property_value(el, 'display', 'table-cell'):
+        if get_css_property_value(el, 'display') in ('table-row', 'table-cell'):
             return False
     return True
 
-def remove_css_property(element, property_name):
-    atrib = cssutils.parseStyle(element.get('style'))
-    atrib.removeProperty(property_name)
-    element.set('style', atrib.getCssText(separator=''))
-    if len(element.get('style')) == 0:
-        element.attrib.pop('style')
+def remove_css_property(el, prop_name):
+    if el.get('style') is None:
+        return
 
+    decls = re.split(r'\s*;\s*', el.get('style'))
+    if decls[-1] == '':
+        decls.pop()
+
+    idx = next((i for i,v in enumerate(decls) if v.startswith(prop_name + ':')), None)
+    if idx is not None:
+        del decls[idx]
+        if len(decls) == 0:
+            el.attrib.pop('style')
+        else:
+            el.set('style', ';'.join(decls))
 
 def get_css_property_value(el, prop_name):
-    atrib = cssutils.parseStyle(el.get('style'))
-    value = atrib.getPropertyCSSValue(prop_name)
-    if value:
-        return value.cssText
+    if el.get('style') is None:
+        return None
+
+    for decl in re.split(r'\s*;\s*', el.get('style')):
+        if decl.startswith(prop_name + ':'):
+            return decl[len(prop_name)+1:].strip()
     return None
 
 def has_css_property_value(el, prop_name, prop_value):
-    value = get_css_property_value(el, prop_name)
-    if value and value == prop_value:
-        return True
-    return False
+    if el.get('style') is None:
+        return False
+
+    regex = r'(^|;)\s*{}:\s*{}(;|$)'.format(re.escape(prop_name), re.escape(prop_value))
+    return re.search(regex, el.get('style')) is not None
 
 def set_css_property_value(el, prop_name, prop_value):
-    atrib = cssutils.parseStyle(el.get('style'))
-    atrib.setProperty(prop_name, prop_value)
-    el.set('style', atrib.getCssText(separator=''))
+    decl = '{}: {}'.format(prop_name, prop_value)
+    style = el.get('style')
+    if style is None or style == '':
+        el.set('style', decl)
+    else:
+        decls = re.split(r'\s*;\s*', style)
+        if decls[-1] == '':
+            decls.pop()
+
+        try:
+            idx = next(i for i,v in enumerate(decls) if v.startswith(prop_name + ':'))
+            decls[idx] = decl
+        except StopIteration:
+            decls.append(decl)
+        el.set('style', ';'.join(decls))
 
 def convert_display_property_to_html_tag(element, element_tag, display_value):
     str_attrib_value = element.get('style')
@@ -170,8 +193,7 @@ def convert_span_tables_to_tr_td(root_el):
 
 def convert_inline_block_elements_to_table(root_el):
     for el in root_el.xpath('//*[contains(@style, "display")]'):
-        if not has_css_property_value(el, 'display', 'inline-block') and \
-                not has_css_property_value(el, 'display', 'inline-table'):
+        if get_css_property_value(el, 'display') not in ('inline-block', 'inline-table'):
             continue
 
         elements_to_put_into_table = [el]
@@ -179,8 +201,7 @@ def convert_inline_block_elements_to_table(root_el):
 
         # find subsequent inline block elements
         while el is not None:
-            if has_css_property_value(el, 'display', 'inline-block') or \
-                    has_css_property_value(el, 'display', 'inline-table'):
+            if get_css_property_value(el, 'display') in ('inline-block', 'inline-table'):
                 elements_to_put_into_table.append(el)
             else:
                 break

--- a/premailer/LICENSE
+++ b/premailer/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2009-2012, Peter Bengtsson
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Peter Bengtsson nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Peter Bengtsson OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/premailer/__init__.py
+++ b/premailer/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import, unicode_literals
+from .premailer import Premailer, transform
+
+__version__ = '3.2.0'

--- a/premailer/__main__.py
+++ b/premailer/__main__.py
@@ -1,0 +1,156 @@
+from __future__ import absolute_import, unicode_literals
+import sys
+import argparse
+
+from .premailer import Premailer
+
+
+def main(args):
+    """Command-line tool to transform html style to inline css
+
+    Usage::
+
+        $ echo '<style>h1 { color:red; }</style><h1>Title</h1>' | \
+        python -m premailer
+        <h1 style="color:red"></h1>
+        $ cat newsletter.html | python -m premailer
+    """
+
+    parser = argparse.ArgumentParser(usage='python -m premailer [options]')
+
+    parser.add_argument(
+        "-f", "--file", nargs='?', type=argparse.FileType('r'),
+        help="Specifies the input file.  The default is stdin.",
+        default=sys.stdin, dest="infile"
+    )
+
+    parser.add_argument(
+        "-o", "--output", nargs='?', type=argparse.FileType('w'),
+        help="Specifies the output file.  The default is stdout.",
+        default=sys.stdout, dest="outfile"
+    )
+
+    parser.add_argument(
+        "--base-url", default=None, type=str, dest="base_url"
+    )
+
+    parser.add_argument(
+        "--remove-internal-links", default=True,
+        help="Remove links that start with a '#' like anchors.",
+        dest="preserve_internal_links"
+    )
+
+    parser.add_argument(
+        "--exclude-pseudoclasses", default=False,
+        help="Pseudo classes like p:last-child', p:first-child, etc",
+        action="store_true", dest="exclude_pseudoclasses"
+    )
+
+    parser.add_argument(
+        "--preserve-style-tags", default=False,
+        help="Do not delete <style></style> tags from the html document.",
+        action="store_true", dest="keep_style_tags"
+    )
+
+    parser.add_argument(
+        "--remove-star-selectors", default=True,
+        help="All wildcard selectors like '* {color: black}' will be removed.",
+        action="store_false", dest="include_star_selectors"
+    )
+
+    parser.add_argument(
+        "--remove-classes", default=False,
+        help="Remove all class attributes from all elements",
+        action="store_true", dest="remove_classes"
+    )
+
+    parser.add_argument(
+        "--capitalize-float-margin", default=False,
+        help="Capitalize float and margin properties for outlook.com compat.",
+        action="store_true", dest="capitalize_float_margin"
+    )
+
+    parser.add_argument(
+        "--strip-important", default=False,
+        help="Remove '!important' for all css declarations.",
+        action="store_true", dest="strip_important"
+    )
+
+    parser.add_argument(
+        "--method", default="html", dest="method",
+        help="The type of html to output. 'html' for HTML, 'xml' for XHTML."
+    )
+
+    parser.add_argument(
+        "--base-path", default=None, dest="base_path",
+        help="The base path for all external stylsheets."
+    )
+
+    parser.add_argument(
+        "--external-style", action="append", dest="external_styles",
+        help="The path to an external stylesheet to be loaded."
+    )
+
+    parser.add_argument(
+        "--css-text", action="append", dest="css_text",
+        help="CSS text to be applied to the html."
+    )
+
+    parser.add_argument(
+        "--disable-basic-attributes", dest="disable_basic_attributes",
+        help="Disable provided basic attributes (comma separated)", default=[]
+    )
+
+    parser.add_argument(
+        "--disable-validation", default=False,
+        action="store_true", dest="disable_validation",
+        help="Disable CSSParser validation of attributes and values",
+    )
+
+    parser.add_argument(
+        "--pretty", default=False,
+        action="store_true",
+        help="Pretty-print the outputted HTML.",
+    )
+
+    parser.add_argument(
+        "--encoding", default='utf-8',
+        help="Output encoding. The default is utf-8",
+    )
+
+    options = parser.parse_args(args)
+
+    if options.disable_basic_attributes:
+        options.disable_basic_attributes = (
+            options.disable_basic_attributes.split()
+        )
+
+    html = options.infile.read()
+    if hasattr(html, 'decode'):  # Forgive me: Python 2 compatability
+        html = html.decode('utf-8')
+
+    p = Premailer(
+        html=html,
+        base_url=options.base_url,
+        preserve_internal_links=options.preserve_internal_links,
+        exclude_pseudoclasses=options.exclude_pseudoclasses,
+        keep_style_tags=options.keep_style_tags,
+        include_star_selectors=options.include_star_selectors,
+        remove_classes=options.remove_classes,
+        strip_important=options.strip_important,
+        external_styles=options.external_styles,
+        css_text=options.css_text,
+        method=options.method,
+        base_path=options.base_path,
+        disable_basic_attributes=options.disable_basic_attributes,
+        disable_validation=options.disable_validation
+    )
+    options.outfile.write(p.transform(
+        encoding=options.encoding,
+        pretty_print=options.pretty
+    ))
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/premailer/cache.py
+++ b/premailer/cache.py
@@ -1,0 +1,85 @@
+import functools
+
+
+class _HashedSeq(list):
+    # # From CPython
+    __slots__ = 'hashvalue'
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+
+# if we only have nonlocal
+class _Cache(object):
+    def __init__(self):
+        self.off = False
+        self.missed = 0
+        self.cache = {}
+
+
+def function_cache(expected_max_entries=1000):
+    """
+        function_cache is a decorator for caching function call
+        the argument to the wrapped function must be hashable else
+        it will not work
+
+        expected_max_entries is for protecting cache failure. If cache
+        misses more than this number the cache will turn off itself.
+        Specify None you sure that the cache  will not cause memory
+        limit problem.
+
+        Args:
+            expected_max_entries(integer OR None): will raise if not correct
+
+        Returns:
+            function
+
+    """
+    if (
+        expected_max_entries is not None and
+        not isinstance(expected_max_entries, int)
+    ):
+        raise TypeError(
+            'Expected expected_max_entries to be an integer or None'
+        )
+
+    # indicator of cache missed
+    sentinel = object()
+
+    def decorator(func):
+        cached = _Cache()
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            if cached.off:
+                return func(*args, **kwargs)
+
+            keys = args
+            if kwargs:
+                sorted_items = sorted(kwargs.items())
+                for item in sorted_items:
+                    keys += item
+
+            hashed = hash(_HashedSeq(keys))
+            result = cached.cache.get(hashed, sentinel)
+            if result is sentinel:
+                cached.missed += 1
+                result = func(*args, **kwargs)
+                cached.cache[hashed] = result
+                # # something is wrong if we are here more than expected
+                # # empty and turn it off
+                if (
+                    expected_max_entries is not None and
+                    cached.missed > expected_max_entries
+                ):
+                    cached.off = True
+                    cached.cache.clear()
+
+            return result
+
+        return inner
+    return decorator

--- a/premailer/merge_style.py
+++ b/premailer/merge_style.py
@@ -1,0 +1,113 @@
+import cssutils
+import threading
+from operator import itemgetter
+try:
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    # some old python 2.6 thing then, eh?
+    from ordereddict import OrderedDict
+
+
+def format_value(prop):
+    if prop.priority == "important":
+        return prop.propertyValue.cssText.strip() + ' !important'
+    else:
+        return prop.propertyValue.cssText.strip()
+
+
+def csstext_to_pairs(csstext):
+    """
+    csstext_to_pairs takes css text and make it to list of
+    tuple of key,value.
+    """
+    # The lock is required to avoid ``cssutils`` concurrency
+    # issues documented in issue #65
+    with csstext_to_pairs._lock:
+        return sorted(
+            [
+                (prop.name.strip(), format_value(prop))
+                for prop in cssutils.parseStyle(csstext)
+            ],
+            key=itemgetter(0)
+        )
+
+
+csstext_to_pairs._lock = threading.RLock()
+
+
+def merge_styles(
+        inline_style,
+        new_styles,
+        classes,
+        remove_unset_properties=False
+):
+    """
+        This will merge all new styles where the order is important
+        The last one will override the first
+        When that is done it will apply old inline style again
+        The old inline style is always important and override
+        all new ones. The inline style must be valid.
+
+        Args:
+            inline_style(str): the old inline style of the element if there
+                is one
+            new_styles: a list of new styles, each element should be
+                a list of tuple
+            classes: a list of classes which maps new_styles, important!
+            remove_unset_properties(bool): Allow us to remove certain CSS
+                properties with rules that set their value to 'unset'
+
+        Returns:
+            str: the final style
+    """
+    # building classes
+    styles = OrderedDict([('', OrderedDict())])
+    for pc in set(classes):
+        styles[pc] = OrderedDict()
+
+    for i, style in enumerate(new_styles):
+        for k, v in style:
+            styles[classes[i]][k] = v
+
+    # keep always the old inline style
+    if inline_style:
+        # inline should be a declaration list as I understand
+        # ie property-name:property-value;...
+        for k, v in csstext_to_pairs(inline_style):
+            styles[''][k] = v
+
+    normal_styles = []
+    pseudo_styles = []
+    for pseudoclass, kv in styles.items():
+        if remove_unset_properties:
+            # Remove rules that we were going to have value 'unset' because
+            # they effectively are the same as not saying anything about the
+            # property when inlined
+            kv = OrderedDict(
+                (k, v) for (k, v) in kv.items() if not v.lower() == 'unset'
+            )
+        if not kv:
+            continue
+        if pseudoclass:
+            pseudo_styles.append(
+                '%s{%s}' % (
+                    pseudoclass,
+                    '; '.join('%s:%s' % (k, v) for k, v in kv.items())
+                )
+            )
+        else:
+            normal_styles.append('; '.join(
+                '%s:%s' % (k, v) for k, v in kv.items()
+            ))
+
+    if pseudo_styles:
+        # if we do or code thing correct this should not happen
+        # inline style definition: declarations without braces
+        all_styles = (
+            (['{%s}' % ''.join(normal_styles)] + pseudo_styles)
+            if normal_styles else pseudo_styles
+        )
+    else:
+        all_styles = normal_styles
+
+    return ' '.join(all_styles).strip()

--- a/premailer/premailer.py
+++ b/premailer/premailer.py
@@ -1,0 +1,678 @@
+from __future__ import absolute_import, unicode_literals, print_function
+import codecs
+import operator
+import os
+import re
+import warnings
+try:
+    from collections import OrderedDict
+except ImportError:  # pragma: no cover
+    # some old python 2.6 thing then, eh?
+    from ordereddict import OrderedDict
+import sys
+if sys.version_info >= (3,):  # pragma: no cover
+    # As in, Python 3
+    from io import StringIO
+    from urllib.parse import urljoin, urlparse
+    STR_TYPE = str
+else:  # Python 2
+    try:
+        from cStringIO import StringIO
+    except ImportError:  # pragma: no cover
+        from StringIO import StringIO
+        StringIO = StringIO  # shut up pyflakes
+    from urlparse import urljoin, urlparse
+    STR_TYPE = basestring  # NOQA
+
+import cssutils
+import requests
+from lxml import etree
+from lxml.cssselect import CSSSelector
+from premailer.merge_style import merge_styles, csstext_to_pairs
+from premailer.cache import function_cache
+
+__all__ = ['PremailerError', 'Premailer', 'transform']
+
+
+class PremailerError(Exception):
+    pass
+
+
+class ExternalNotFoundError(ValueError):
+    pass
+
+
+def make_important(bulk):
+    """makes every property in a string !important.
+    """
+    return ';'.join('%s !important' % p if not p.endswith('!important') else p
+                    for p in bulk.split(';'))
+
+
+def get_or_create_head(root):
+    """Ensures that `root` contains a <head> element and returns it.
+    """
+    head = CSSSelector('head')(root)
+    if not head:
+        head = etree.Element('head')
+        body = CSSSelector('body')(root)[0]
+        body.getparent().insert(0, head)
+        return head
+    else:
+        return head[0]
+
+
+@function_cache()
+def _cache_parse_css_string(css_body, validate=True):
+    """
+        This function will cache the result from cssutils
+        It is a big gain when number of rules is big
+        Maximum cache entries are 1000. This is mainly for
+        protecting memory leak in case something gone wild.
+        Be aware that you can turn the cache off in Premailer
+
+        Args:
+            css_body(str): css rules in string format
+            validate(bool): if cssutils should validate
+
+        Returns:
+            cssutils.css.cssstylesheet.CSSStyleSheet
+
+    """
+    return cssutils.parseString(css_body, validate=validate)
+
+
+def capitalize_float_margin(css_body):
+    """Capitalize float and margin CSS property names
+    """
+    def _capitalize_property(match):
+        return '{0}:{1}{2}'.format(
+            match.group('property').capitalize(),
+            match.group('value'),
+            match.group('terminator'))
+
+    return _lowercase_margin_float_rule.sub(_capitalize_property, css_body)
+
+
+_element_selector_regex = re.compile(r'(^|\s)\w')
+_cdata_regex = re.compile(r'\<\!\[CDATA\[(.*?)\]\]\>', re.DOTALL)
+_lowercase_margin_float_rule = re.compile(
+    r'''(?P<property>margin(-(top|bottom|left|right))?|float)
+        :
+        (?P<value>.*?)
+        (?P<terminator>$|;)''',
+    re.IGNORECASE | re.VERBOSE)
+_importants = re.compile('\s*!important')
+#: The short (3-digit) color codes that cause issues for IBM Notes
+_short_color_codes = re.compile(r'^#([0-9a-f])([0-9a-f])([0-9a-f])$', re.I)
+
+# These selectors don't apply to all elements. Rather, they specify
+# which elements to apply to.
+FILTER_PSEUDOSELECTORS = [':last-child', ':first-child', 'nth-child']
+
+
+class Premailer(object):
+
+    attribute_name = 'data-premailer'
+
+    def __init__(self, html, base_url=None,
+                 disable_link_rewrites=False,
+                 preserve_internal_links=False,
+                 preserve_inline_attachments=True,
+                 exclude_pseudoclasses=True,
+                 keep_style_tags=False,
+                 include_star_selectors=False,
+                 remove_classes=False,
+                 capitalize_float_margin=False,
+                 strip_important=True,
+                 external_styles=None,
+                 css_text=None,
+                 method="html",
+                 base_path=None,
+                 disable_basic_attributes=None,
+                 disable_validation=False,
+                 cache_css_parsing=True,
+                 cssutils_logging_handler=None,
+                 cssutils_logging_level=None,
+                 disable_leftover_css=False,
+                 align_floating_images=True,
+                 remove_unset_properties=True):
+        self.html = html
+        self.base_url = base_url
+
+        # If base_url is specified, it is used for loading external stylesheets
+        # via relative URLs.
+        #
+        # Also, if base_url is specified, premailer will transform all URLs by
+        # joining them with the base_url. Setting preserve_internal_links to
+        # True will disable this behavior for links to named anchors. Setting
+        # preserve_inline_attachments to True will disable this behavior for
+        # any links with cid: scheme. Setting disable_link_rewrites to True
+        # will disable this behavior altogether.
+        self.disable_link_rewrites = disable_link_rewrites
+        self.preserve_internal_links = preserve_internal_links
+        self.preserve_inline_attachments = preserve_inline_attachments
+        self.exclude_pseudoclasses = exclude_pseudoclasses
+        # whether to delete the <style> tag once it's been processed
+        # this will always preserve the original css
+        self.keep_style_tags = keep_style_tags
+        self.remove_classes = remove_classes
+        self.capitalize_float_margin = capitalize_float_margin
+        # whether to process or ignore selectors like '* { foo:bar; }'
+        self.include_star_selectors = include_star_selectors
+        if isinstance(external_styles, STR_TYPE):
+            external_styles = [external_styles]
+        self.external_styles = external_styles
+        if isinstance(css_text, STR_TYPE):
+            css_text = [css_text]
+        self.css_text = css_text
+        self.strip_important = strip_important
+        self.method = method
+        self.base_path = base_path
+        if disable_basic_attributes is None:
+            disable_basic_attributes = []
+        self.disable_basic_attributes = disable_basic_attributes
+        self.disable_validation = disable_validation
+        self.cache_css_parsing = cache_css_parsing
+        self.disable_leftover_css = disable_leftover_css
+        self.align_floating_images = align_floating_images
+        self.remove_unset_properties = remove_unset_properties
+
+        if cssutils_logging_handler:
+            cssutils.log.addHandler(cssutils_logging_handler)
+        if cssutils_logging_level:
+            cssutils.log.setLevel(cssutils_logging_level)
+
+    def _parse_css_string(self, css_body, validate=True):
+        if self.cache_css_parsing:
+            return _cache_parse_css_string(css_body, validate=validate)
+
+        return cssutils.parseString(css_body, validate=validate)
+
+    def _parse_style_rules(self, css_body, ruleset_index):
+        """Returns a list of rules to apply to this doc and a list of rules
+        that won't be used because e.g. they are pseudoclasses. Rules
+        look like: (specificity, selector, bulk)
+        for example: ((0, 1, 0, 0, 0), u'.makeblue', u'color:blue').
+        The bulk of the rule should not end in a semicolon.
+        """
+
+        def format_css_property(prop):
+            if self.strip_important or prop.priority != 'important':
+                return '{0}:{1}'.format(prop.name, prop.value)
+            else:
+                return '{0}:{1} !important'.format(prop.name, prop.value)
+
+        def join_css_properties(properties):
+            """ Accepts a list of cssutils Property objects and returns
+            a semicolon delimitted string like 'color: red; font-size: 12px'
+            """
+            return ';'.join(
+                format_css_property(prop)
+                for prop in properties
+            )
+
+        leftover = []
+        rules = []
+        # empty string
+        if not css_body:
+            return rules, leftover
+        sheet = self._parse_css_string(
+            css_body,
+            validate=not self.disable_validation
+        )
+        for rule in sheet:
+            # handle media rule
+            if rule.type == rule.MEDIA_RULE:
+                leftover.append(rule)
+                continue
+            # only proceed for things we recognize
+            if rule.type != rule.STYLE_RULE:
+                continue
+
+            # normal means it doesn't have "!important"
+            normal_properties = [
+                prop for prop in rule.style.getProperties()
+                if prop.priority != 'important'
+            ]
+            important_properties = [
+                prop for prop in rule.style.getProperties()
+                if prop.priority == 'important'
+            ]
+
+            # Create three strings that we can use to add to the `rules`
+            # list later as ready blocks of css.
+            bulk_normal = join_css_properties(normal_properties)
+            bulk_important = join_css_properties(important_properties)
+            bulk_all = join_css_properties(
+                normal_properties + important_properties
+            )
+
+            selectors = (
+                x.strip()
+                for x in rule.selectorText.split(',')
+                if x.strip() and not x.strip().startswith('@')
+            )
+            for selector in selectors:
+                if (':' in selector and self.exclude_pseudoclasses and
+                    ':' + selector.split(':', 1)[1]
+                        not in FILTER_PSEUDOSELECTORS):
+                    # a pseudoclass
+                    leftover.append((selector, bulk_all))
+                    continue
+                elif '*' in selector and not self.include_star_selectors:
+                    continue
+                elif selector.startswith(':'):
+                    continue
+
+                # Crudely calculate specificity
+                id_count = selector.count('#')
+                class_count = selector.count('.')
+                element_count = len(_element_selector_regex.findall(selector))
+
+                # Within one rule individual properties have different
+                # priority depending on !important.
+                # So we split each rule into two: one that includes all
+                # the !important declarations and another that doesn't.
+                for is_important, bulk in (
+                    (1, bulk_important), (0, bulk_normal)
+                ):
+                    if not bulk:
+                        # don't bother adding empty css rules
+                        continue
+                    specificity = (
+                        is_important,
+                        id_count,
+                        class_count,
+                        element_count,
+                        ruleset_index,
+                        len(rules)  # this is the rule's index number
+                    )
+                    rules.append((specificity, selector, bulk))
+
+        return rules, leftover
+
+    def transform(self, pretty_print=True, **kwargs):
+        """change the self.html and return it with CSS turned into style
+        attributes.
+        """
+        if hasattr(self.html, "getroottree"):
+            # skip the next bit
+            root = self.html.getroottree()
+            page = root
+            tree = root
+        else:
+            if self.method == 'xml':
+                parser = etree.XMLParser(
+                    ns_clean=False,
+                    resolve_entities=False
+                )
+            else:
+                parser = etree.HTMLParser()
+            stripped = self.html.strip()
+            tree = etree.fromstring(stripped, parser).getroottree()
+            page = tree.getroot()
+            # lxml inserts a doctype if none exists, so only include it in
+            # the root if it was in the original html.
+            root = tree if stripped.startswith(tree.docinfo.doctype) else page
+
+        assert page is not None
+
+        if self.disable_leftover_css:
+            head = None
+        else:
+            head = get_or_create_head(tree)
+        #
+        # style selectors
+        #
+
+        rules = []
+        index = 0
+
+        for element in CSSSelector('style,link[rel~=stylesheet]')(page):
+            # If we have a media attribute whose value is anything other than
+            # 'all' or 'screen', ignore the ruleset.
+            media = element.attrib.get('media')
+            if media and media not in ('all', 'screen'):
+                continue
+
+            data_attribute = element.attrib.get(self.attribute_name)
+            if data_attribute:
+                if data_attribute == 'ignore':
+                    del element.attrib[self.attribute_name]
+                    continue
+                else:
+                    warnings.warn(
+                        'Unrecognized %s attribute (%r)' % (
+                            self.attribute_name,
+                            data_attribute,
+                        )
+                    )
+
+            is_style = element.tag == 'style'
+            if is_style:
+                css_body = element.text
+            else:
+                href = element.attrib.get('href')
+                css_body = self._load_external(href)
+
+            these_rules, these_leftover = self._parse_style_rules(
+                css_body, index
+            )
+            index += 1
+            rules.extend(these_rules)
+            parent_of_element = element.getparent()
+            if these_leftover or self.keep_style_tags:
+                if is_style:
+                    style = element
+                else:
+                    style = etree.Element('style')
+                    style.attrib['type'] = 'text/css'
+                if self.keep_style_tags:
+                    style.text = css_body
+                else:
+                    style.text = self._css_rules_to_string(these_leftover)
+                if self.method == 'xml':
+                    style.text = etree.CDATA(style.text)
+
+                if not is_style:
+                    element.addprevious(style)
+                    parent_of_element.remove(element)
+
+            elif not self.keep_style_tags or not is_style:
+                parent_of_element.remove(element)
+
+        # external style files
+        if self.external_styles:
+            for stylefile in self.external_styles:
+                css_body = self._load_external(stylefile)
+                self._process_css_text(css_body, index, rules, head)
+                index += 1
+
+        # css text
+        if self.css_text:
+            for css_body in self.css_text:
+                self._process_css_text(css_body, index, rules, head)
+                index += 1
+
+        # rules is a tuple of (specificity, selector, styles), where
+        # specificity is a tuple ordered such that more specific
+        # rules sort larger.
+        rules.sort(key=operator.itemgetter(0))
+
+        # collecting all elements that we need to apply rules on
+        # id is unique for the lifetime of the object
+        # and lxml should give us the same everytime during this run
+        # item id -> {item: item, classes: [], style: []}
+        elements = {}
+        for _, selector, style in rules:
+            new_selector = selector
+            class_ = ''
+            if ':' in selector:
+                new_selector, class_ = re.split(':', selector, 1)
+                class_ = ':%s' % class_
+            # Keep filter-type selectors untouched.
+            if class_ in FILTER_PSEUDOSELECTORS:
+                class_ = ''
+            else:
+                selector = new_selector
+
+            assert selector
+            sel = CSSSelector(selector)
+            items = sel(page)
+            if len(items):
+                # same so process it first
+                processed_style = csstext_to_pairs(style)
+
+                for item in items:
+                    item_id = id(item)
+                    if item_id not in elements:
+                        elements[item_id] = {
+                            'item': item,
+                            'classes': [],
+                            'style': [],
+                        }
+
+                    elements[item_id]['style'].append(processed_style)
+                    elements[item_id]['classes'].append(class_)
+
+        # Now apply inline style
+        # merge style only once for each element
+        # crucial when you have a lot of pseudo/classes
+        # and a long list of elements
+        for _, element in elements.items():
+            final_style = merge_styles(
+                element['item'].attrib.get('style', ''),
+                element['style'],
+                element['classes'],
+                remove_unset_properties=self.remove_unset_properties,
+            )
+            if final_style:
+                # final style could be empty string because of
+                # remove_unset_properties
+                element['item'].attrib['style'] = final_style
+            self._style_to_basic_html_attributes(
+                element['item'],
+                final_style,
+                force=True
+            )
+
+        if self.remove_classes:
+            # now we can delete all 'class' attributes
+            for item in page.xpath('//@class'):
+                parent = item.getparent()
+                del parent.attrib['class']
+
+        # Capitalize Margin properties
+        # To fix weird outlook bug
+        # https://www.emailonacid.com/blog/article/email-development/outlook.com-does-support-margins
+        if self.capitalize_float_margin:
+            for item in page.xpath('//@style'):
+                mangled = capitalize_float_margin(item)
+                item.getparent().attrib['style'] = mangled
+
+        # Add align attributes to images if they have a CSS float value of
+        # right or left. Outlook (both on desktop and on the web) are bad at
+        # understanding floats, but they do understand the HTML align attrib.
+        if self.align_floating_images:
+            for item in page.xpath('//img[@style]'):
+                image_css = cssutils.parseStyle(item.attrib['style'])
+                if image_css.float == 'right':
+                    item.attrib['align'] = 'right'
+                elif image_css.float == 'left':
+                    item.attrib['align'] = 'left'
+
+        #
+        # URLs
+        #
+        if self.base_url and not self.disable_link_rewrites:
+            if not urlparse(self.base_url).scheme:
+                raise ValueError('Base URL must have a scheme')
+            for attr in ('href', 'src'):
+                for item in page.xpath("//@%s" % attr):
+                    parent = item.getparent()
+                    url = parent.attrib[attr]
+                    if (
+                        attr == 'href' and self.preserve_internal_links and
+                        url.startswith('#')
+                    ):
+                        continue
+                    if (
+                        attr == 'src' and self.preserve_inline_attachments and
+                        url.startswith('cid:')
+                    ):
+                        continue
+                    if attr == 'href' and url.startswith('tel:'):
+                        continue
+                    parent.attrib[attr] = urljoin(self.base_url, url)
+
+        if hasattr(self.html, "getroottree"):
+            return root
+        else:
+            kwargs.setdefault('method', self.method)
+            kwargs.setdefault('pretty_print', pretty_print)
+            kwargs.setdefault('encoding', 'utf-8')  # As Ken Thompson intended
+            out = etree.tostring(root, **kwargs).decode(kwargs['encoding'])
+            if self.method == 'xml':
+                out = _cdata_regex.sub(
+                    lambda m: '/*<![CDATA[*/%s/*]]>*/' % m.group(1),
+                    out
+                )
+            if self.strip_important:
+                out = _importants.sub('', out)
+            return out
+
+    def _load_external_url(self, url):
+        return requests.get(url).text
+
+    def _load_external(self, url):
+        """loads an external stylesheet from a remote url or local path
+        """
+        if url.startswith('//'):
+            # then we have to rely on the base_url
+            if self.base_url and 'https://' in self.base_url:
+                url = 'https:' + url
+            else:
+                url = 'http:' + url
+
+        if url.startswith('http://') or url.startswith('https://'):
+            css_body = self._load_external_url(url)
+        else:
+            stylefile = url
+            if not os.path.isabs(stylefile):
+                stylefile = os.path.abspath(
+                    os.path.join(self.base_path or '', stylefile)
+                )
+            if os.path.exists(stylefile):
+                with codecs.open(stylefile, encoding='utf-8') as f:
+                    css_body = f.read()
+            elif self.base_url:
+                url = urljoin(self.base_url, url)
+                return self._load_external(url)
+            else:
+                raise ExternalNotFoundError(stylefile)
+
+        return css_body
+
+    @staticmethod
+    def six_color(color_value):
+        """Fix background colors for Lotus Notes
+
+        Notes which fails to handle three character ``bgcolor`` codes well.
+        see <https://github.com/peterbe/premailer/issues/114>"""
+
+        # Turn the color code from three to six digits
+        retval = _short_color_codes.sub(r'#\1\1\2\2\3\3', color_value)
+        return retval
+
+    def _style_to_basic_html_attributes(self, element, style_content,
+                                        force=False):
+        """given an element and styles like
+        'background-color:red; font-family:Arial' turn some of that into HTML
+        attributes. like 'bgcolor', etc.
+
+        Note, the style_content can contain pseudoclasses like:
+        '{color:red; border:1px solid green} :visited{border:1px solid green}'
+        """
+        if (
+            style_content.count('}') and
+            style_content.count('{') == style_content.count('}')
+        ):
+            style_content = style_content.split('}')[0][1:]
+
+        attributes = OrderedDict()
+        for key, value in [x.split(':') for x in style_content.split(';')
+                           if len(x.split(':')) == 2]:
+            key = key.strip()
+
+            if key == 'text-align':
+                attributes['align'] = value.strip()
+            elif key == 'vertical-align':
+                attributes['valign'] = value.strip()
+            elif (
+                key == 'background-color' and
+                'transparent' not in value.lower()
+            ):
+                # Only add the 'bgcolor' attribute if the value does not
+                # contain the word "transparent"; before we add it possibly
+                # correct the 3-digit color code to its 6-digit equivalent
+                # ("abc" to "aabbcc") so IBM Notes copes.
+                attributes['bgcolor'] = self.six_color(value.strip())
+            elif key == 'width' or key == 'height':
+                value = value.strip()
+                if value.endswith('px'):
+                    value = value[:-2]
+                attributes[key] = value
+
+        for key, value in attributes.items():
+            if (
+                key in element.attrib and not force or
+                key in self.disable_basic_attributes
+            ):
+                # already set, don't dare to overwrite
+                continue
+            element.attrib[key] = value
+
+    def _css_rules_to_string(self, rules):
+        """given a list of css rules returns a css string
+        """
+        lines = []
+        for item in rules:
+            if isinstance(item, tuple):
+                k, v = item
+                lines.append('%s {%s}' % (k, make_important(v)))
+            # media rule
+            else:
+                for rule in item.cssRules:
+                    if isinstance(rule, cssutils.css.csscomment.CSSComment):
+                        continue
+                    for key in rule.style.keys():
+                        rule.style[key] = (
+                            rule.style.getPropertyValue(key, False),
+                            '!important'
+                        )
+                lines.append(item.cssText)
+        return '\n'.join(lines)
+
+    def _process_css_text(self, css_text, index, rules, head):
+        """processes the given css_text by adding rules that can be
+        in-lined to the given rules list and adding any that cannot
+        be in-lined to the given `<head>` element.
+        """
+        these_rules, these_leftover = self._parse_style_rules(css_text, index)
+        rules.extend(these_rules)
+        if head is not None and (these_leftover or self.keep_style_tags):
+            style = etree.Element('style')
+            style.attrib['type'] = 'text/css'
+            if self.keep_style_tags:
+                style.text = css_text
+            else:
+                style.text = self._css_rules_to_string(these_leftover)
+            head.append(style)
+
+
+def transform(html, base_url=None):
+    return Premailer(html, base_url=base_url).transform()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    html = """<html>
+        <head>
+        <title>Test</title>
+        <style>
+        h1, h2 { color:red; }
+        strong {
+          text-decoration:none
+          }
+        p { font-size:2px }
+        p.footer { font-size: 1px}
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        <p class="footer" style="color:red">Feetnuts</p>
+        </body>
+        </html>"""
+    p = Premailer(html)
+    print(p.transform())

--- a/premailer/tests/test-apple-newsletter.html
+++ b/premailer/tests/test-apple-newsletter.html
@@ -1,0 +1,101 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+        <title> Newsletter</title>
+	<meta name="viewport" content="width = 620" />
+<style type="text/css">
+img {margin:0}
+a.bluelink:link,a.bluelink:visited,a.bluelink:active {color:#5b7ab3; text-decoration: none}
+a.bluelink:hover {color:#5b7ab3; text-decoration: underline}
+</style>
+<style media="only screen and (max-device-width: 480px)" type="text/css">
+* {line-height: normal !important; -webkit-text-size-adjust: 125%}
+</style>
+</head>
+
+<body bgcolor="#FFFFFF" style="margin:0; padding:0">
+<table width="100%" bgcolor="#FFFFFF" cellpadding="0" cellspacing="0" align="center" border="2">
+	<tr>
+		<td style="padding: 30px"><!--
+--><table width="636" border="0" cellspacing="0" cellpadding="0" align="center">
+	<tr>
+		<td width="636"><img src="http://images.apple.com/data/retail/us/topcap.gif" border="0" alt="" width="636" height="62" style="display:block" /></td>
+	</tr>
+</table><!--
+--><table width="636" border="1" cellspacing="0" cellpadding="0" align="center" bgcolor="#fffef6">
+	<tr>
+		<td width="59" valign="top" background="http://images.apple.com/data/retail/us/leftbg.gif"><img src="http://images.apple.com/data/retail/us/leftcap.gif" width="59" height="302" border="1" alt="" style="display:block" /></td>
+		<td width="500" align="left" valign="top"><!--
+--><table width="500" border="1" cellspacing="0" cellpadding="0">
+	<tr>
+		<td width="379" align="left" valign="top">
+<div><img src="http://images.apple.com/data/retail/us/headline.gif" width="330" height="29" border="1" alt="Thanks for making a reservation." style="display:block" /></div>
+		</td>
+		<td width="21" align="right" valign="top">
+<div><img src="http://images.apple.com/data/retail/us/applelogo.gif" width="21" height="25" border="1" alt="" style="display:block" /></div>
+		</td>
+	</tr>
+</table><!--
+--><table width="500" border="1" cellspacing="0" cellpadding="0">
+	<tr>
+		<td width="500" align="left" valign="top">
+<div><img src="http://images.apple.com/data/retail/us/line.gif" width="500" height="36" border="0" alt="" style="display:block" /></div>
+		</td>
+	</tr>
+</table><!--
+--><table width="500" border="1" cellspacing="0" cellpadding="0">
+	<tr>
+		<td width="10" align="left" valign="top"></td>
+		<td width="340" align="left" valign="top">
+
+
+<div style="margin: 0; padding: 2px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Dear peter,</div>
+<div style="margin: 0; padding: 12px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">You are scheduled for a Genius Bar appointment.</div>
+<div style="margin: 0; padding: 12px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Topic: <b>iPhone</b></div>
+<div style="margin: 0; padding: 12px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Date: <b>Wednesday, Aug 26, 2009</b></div>
+<div style="margin: 0; padding: 12px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Time: <b>11:10AM</b></div>
+<div style="margin: 0; padding: 12px 10px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Location: <b>Apple Store, Regent Street</b></div>
+		</td>
+		<td width="150" align="left" valign="top">
+<div style="margin: 0; padding: 2px 0 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color:#808285; font-size:11px; line-height: 13px">Apple Store,</div>
+<div style="margin: 0; padding: 0 0 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color:#808285; font-size:11px; line-height: 13px">Regent Street</div>
+<div style="margin: 0; padding: 7px 0 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color:#808285; font-size:11px; line-height: 13px"><a href="http://concierge.apple.com/WebObjects/RRSServices.woa/wa/ics?id=ewoJInByaW1hcnlLZXkiID0gewoJCSJyZXNlcnZhdGlvbklEIiA9ICI1ODEyMDI2NCI7Cgl9OwoJImVudGl0eU5hbWUiID0gIlJlc2VydmF0aW9uIjsKfQ%3D%3D" style="font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; font-size:11px; color:#5b7ab3" class="bluelink">Add this to your calendar<img src="http://images.apple.com/data/retail/us/bluearrow.gif" width="8" height="8" border="0" alt="" style="display:inline; margin:0" /></a></div>
+<div style="margin: 0; padding: 7px 0 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color:#808285; font-size:11px; line-height: 13px">If you are no longer able to attend this session, please <a href="http://concierge.apple.com/WebObjects/Concierge.woa/wa/cancelReservation?r=ewoJInByaW1hcnlLZXkiID0gewoJCSJyZXNlcnZhdGlvbklEIiA9ICI1ODEyMDI2NCI7Cgl9OwoJImVudGl0eU5hbWUiID0gIlJlc2VydmF0aW9uIjsKfQ%3D%3D" style="font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; font-size:11px; color:#5b7ab3" class="bluelink">cancel</a> or <a href="http://concierge.apple.com/WebObjects/Concierge.woa/wa/cancelReservation?r=ewoJInByaW1hcnlLZXkiID0gewoJCSJyZXNlcnZhdGlvbklEIiA9ICI1ODEyMDI2NCI7Cgl9OwoJImVudGl0eU5hbWUiID0gIlJlc2VydmF0aW9uIjsKfQ%3D%3D" style="font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; font-size:11px; color:#5b7ab3" class="bluelink">reschedule</a> your reservation.</div>
+<div style="margin: 0; padding: 7px 0 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color:#808285; font-size:11px; line-height: 13px"><a href="http://www.apple.com/retail/../uk/retail/regentstreet/map" style="font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; font-size:11px; color:#5b7ab3" class="bluelink">Get directions to the store<img src="http://images.apple.com/data/retail/us/bluearrow.gif" width="8" height="8" border="0" alt="" style="display:inline; margin:0" /></a></div>
+		</td>
+	</tr>
+</table><!--
+--><table width="500" border="1" cellspacing="0" cellpadding="0">
+	<tr>
+    <td width="10"></td>
+				<td width="490" align="left" valign="top">
+				<br>
+<div style="margin: 0; padding: 0 20px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">We look forward to seeing you.</div>
+<div style="margin: 0; padding: 0 20px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Your Apple Store team,</div>
+<div style="margin: 0; padding: 0 20px 0 0; font-family: Lucida Grande, Arial, Helvetica, Geneva, Verdana, sans-serif; color: #000000 !important; font-size:12px; line-height: 16px">Regent Street</div>
+		</td>
+	</tr>
+</table><!--
+		--></td>
+		<td width="59" valign="top" background="http://images.apple.com/data/retail/us/rightbg.gif"><img src="http://images.apple.com/data/retail/us/rightcap.gif" width="77" height="302" border="0" alt="" style="display:block" /></td>
+	</tr>
+</table><!--
+--><table width="636" border="1" cellspacing="0" cellpadding="0" align="center">
+	<tr>
+		<td width="636"><img src="http://images.apple.com/data/retail/us/bottomcap.gif" border="0" alt="" width="636" height="62" style="display:block" /></td>
+	</tr>
+</table><!--
+BEGIN FOOTER
+--><table width="498" border="1" cellspacing="0" cellpadding="0" align="center">
+	<tr>
+		<td style="padding-top:22px">
+<div style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px; line-height: 12px; color:#b4b4b4">TM and copyright &copy; 2008 Apple Inc. 1 Infinite Loop, MS 303-3DM, Cupertino, CA 95014.</div>
+<div style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px; line-height: 12px; color:#b4b4b4"><a href="http://www.apple.com/legal/" style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px;line-height: 12px; color:#b4b4b4; text-decoration:underline">All Rights Reserved</a> / <a href="http://www.apple.com/enews/subscribe/"  style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px; line-height: 12px;color:#b4b4b4; text-decoration:underline">Keep Informed</a> / <a href="http://www.apple.com/legal/privacy/" style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px; line-height: 12px; color:#b4b4b4; text-decoration:underline">Privacy Policy</a> / <a href="https://myinfo.apple.com/cgi-bin/WebObjects/MyInfo/" style="font-family: Geneva, Verdana, Arial, Helvetica, sans-serif; font-size:9px; line-height: 12px; color:#b4b4b4; text-decoration:underline">My Info</a></div>
+		</td>
+	</tr>
+</table><!--
+		--></td>
+	</tr>
+</table>
+</body>
+</html>

--- a/premailer/tests/test-external-links.css
+++ b/premailer/tests/test-external-links.css
@@ -1,0 +1,12 @@
+h1 {
+  color: blue;
+}
+h2 {
+  color: green;
+}
+a {
+  color: pink;
+}
+a:hover {
+  color: purple;
+}

--- a/premailer/tests/test-external-styles.css
+++ b/premailer/tests/test-external-styles.css
@@ -1,0 +1,12 @@
+h1 {
+  color: brown;
+}
+h2::after {
+  content: "";
+  display: block;
+}
+@media all and (max-width: 320px) {
+    h1 {
+        font-size: 12px;
+    }
+}

--- a/premailer/tests/test-issue78.html
+++ b/premailer/tests/test-issue78.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+<link href="premailer/tests/test-external-links.css" rel="stylesheet" type="text/css">
+<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml">
+<style type="text/css">
+.yshortcuts a {border-bottom: none !important;}
+@media screen and (max-width: 600px) {
+table[class="container"] {
+width: 100% !important;
+}
+}
+/* Even comments should be preserved when the
+   keep_style_tags flag is set */
+p {font-size:12px;}
+</style>
+</head>
+<body>
+<h1>h1</h1>
+<p><a href="">html</a></p>
+</body>
+</html>

--- a/premailer/tests/test-unicode.html
+++ b/premailer/tests/test-unicode.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unicode Test</title>
+    <style>
+        h1 {
+            font-family: 'Gulim', sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <h1>問題</h1>
+</body>
+</html>

--- a/premailer/tests/test_cache.py
+++ b/premailer/tests/test_cache.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, unicode_literals
+import unittest
+
+from premailer.cache import function_cache
+from nose.tools import raises
+
+
+class TestCache(unittest.TestCase):
+
+    @raises(TypeError)
+    def test_expected_max_entries_raise(self):
+        function_cache(expected_max_entries='testing')
+
+    def test_auto_turn_off(self):
+        test = {'call_count': 0}
+
+        def test_func(*args, **kwargs):
+            test['call_count'] += 1
+
+        cache_decorator = function_cache(expected_max_entries=2)
+        wrapper = cache_decorator(test_func)
+        wrapper(1, 1, t=1)
+        wrapper(1, 2, t=1)
+        # turn off
+        wrapper(1, 3, t=1)
+        # call 10 more times
+        for _ in range(10):
+            wrapper(1, 3, t=1)
+
+        self.assertEqual(test['call_count'], 13)
+
+    def test_cache_hit(self):
+        test = {'call_count': 0}
+
+        def test_func(*args, **kwargs):
+            test['call_count'] += 1
+
+        cache_decorator = function_cache(expected_max_entries=20)
+        wrapper = cache_decorator(test_func)
+        wrapper(1, 1, t=1)
+        wrapper(1, 2, t=1)
+        # turn off
+        wrapper(1, 3, t=1)
+        # call 10 more times
+        for _ in range(10):
+            wrapper(1, 3, t=1)
+            self.assertEqual(test['call_count'], 3)

--- a/premailer/tests/test_merge_style.py
+++ b/premailer/tests/test_merge_style.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+import unittest
+from premailer.merge_style import csstext_to_pairs, merge_styles
+
+
+class TestMergeStyle(unittest.TestCase):
+    # test what is not cover in test_premailer
+    # should move them here
+    # smaller files are easier to work with
+    def test_csstext_to_pairs(self):
+        csstext = 'font-size:1px'
+        parsed_csstext = csstext_to_pairs(csstext)
+        self.assertEqual(('font-size', '1px'), parsed_csstext[0])
+
+    def test_inline_invalid_syntax(self):
+        # Invalid syntax does not raise
+        inline = '{color:pink} :hover{color:purple} :active{color:red}'
+        merge_styles(inline, [], [])

--- a/premailer/tests/test_premailer.py
+++ b/premailer/tests/test_premailer.py
@@ -1,0 +1,2717 @@
+from __future__ import absolute_import, unicode_literals
+import sys
+import re
+import unittest
+import logging
+from contextlib import contextmanager
+if sys.version_info >= (3, ):  # As in, Python 3
+    from urllib.request import urlopen
+else:  # Python 2
+    from urllib2 import urlopen
+    urlopen = urlopen  # shut up pyflakes
+from io import StringIO  # Yes, the is an io lib in py2.x
+
+from nose.tools import eq_, ok_, assert_raises
+import mock
+from lxml.etree import fromstring, XMLSyntaxError
+
+from premailer.premailer import (
+    transform,
+    Premailer,
+    merge_styles,
+    csstext_to_pairs,
+    ExternalNotFoundError,
+)
+from premailer.__main__ import main
+import premailer.premailer  # lint:ok
+
+
+whitespace_between_tags = re.compile('>\s*<')
+
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+@contextmanager
+def provide_input(content):
+    old_stdin = sys.stdin
+    sys.stdin = StringIO(content)
+    try:
+        with captured_output() as (out, err):
+            yield out, err
+    finally:
+        sys.stdin = old_stdin
+        sys.stdin = StringIO(content)
+
+
+class MockResponse(object):
+
+    def __init__(self, content):
+        self.text = content
+
+
+def compare_html(one, two):
+    one = one.strip()
+    two = two.strip()
+    one = whitespace_between_tags.sub('>\n<', one)
+    two = whitespace_between_tags.sub('>\n<', two)
+    one = one.replace('><', '>\n<')
+    two = two.replace('><', '>\n<')
+    for i, line in enumerate(one.splitlines()):
+        other = two.splitlines()[i]
+        if line.lstrip() != other.lstrip():
+            eq_(line.lstrip(), other.lstrip())
+
+
+class Tests(unittest.TestCase):
+
+    def shortDescription(self):
+        # most annoying thing in the world about nose
+        pass
+
+    def test_merge_styles_basic(self):
+        inline_style = 'font-size:1px; color: red'
+        new = 'font-size:2px; font-weight: bold'
+        expect = 'font-size:1px;', 'font-weight:bold;', 'color:red'
+        result = merge_styles(inline_style, [csstext_to_pairs(new)], [''])
+        for each in expect:
+            ok_(each in result)
+
+    def test_merge_styles_with_class(self):
+        inline_style = 'color:red; font-size:1px;'
+        new, class_ = 'font-size:2px; font-weight: bold', ':hover'
+
+        # because we're dealing with dicts (random order) we have to
+        # test carefully.
+        # We expect something like this:
+        #  {color:red; font-size:1px} :hover{font-size:2px; font-weight:bold}
+
+        result = merge_styles(inline_style, [csstext_to_pairs(new)], [class_])
+        ok_(result.startswith('{'))
+        ok_(result.endswith('}'))
+        ok_(' :hover{' in result)
+        split_regex = re.compile('{([^}]+)}')
+        eq_(len(split_regex.findall(result)), 2)
+        expect_first = 'color:red', 'font-size:1px'
+        expect_second = 'font-weight:bold', 'font-size:2px'
+        for each in expect_first:
+            ok_(each in split_regex.findall(result)[0])
+        for each in expect_second:
+            ok_(each in split_regex.findall(result)[1])
+
+    def test_merge_styles_non_trivial(self):
+        inline_style = (
+            'background-image:url("data:image/png;base64,iVBORw0KGg")'
+        )
+        new = 'font-size:2px; font-weight: bold'
+        expect = (
+            'background-image:url("data:image/png;base64,iVBORw0KGg")',
+            'font-size:2px;',
+            'font-weight:bold'
+        )
+        result = merge_styles(inline_style, [csstext_to_pairs(new)], [''])
+        for each in expect:
+            ok_(each in result)
+
+    def test_merge_styles_with_unset(self):
+        inline_style = 'color: red'
+        new = 'font-size: 10px; font-size: unset; font-weight: bold'
+        expect = 'font-weight:bold;', 'color:red'
+        css_new = csstext_to_pairs(new)
+        result = merge_styles(
+            inline_style,
+            [css_new],
+            [''],
+            remove_unset_properties=True,
+        )
+        for each in expect:
+            ok_(each in result)
+        ok_('font-size' not in result)
+
+    def test_basic_html(self):
+        """test the simplest case"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 style="color:red">Hi!</h1>
+        <p><strong style="text-decoration:none">Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_remove_classes(self):
+        """test the simplest case"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        .stuff {
+            color: red;
+        }
+        </style>
+        </head>
+        <body>
+        <p class="stuff"><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <p style="color:red"><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html, remove_classes=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_basic_html_shortcut_function(self):
+        """test the plain transform function"""
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 style="color:red">Hi!</h1>
+        <p><strong style="text-decoration:none">Yes!</strong></p>
+        </body>
+        </html>"""
+
+        result_html = transform(html)
+        compare_html(expect_html, result_html)
+
+    def test_empty_style_tag(self):
+        """empty style tag"""
+
+        html = """<html>
+        <head>
+        <title></title>
+        <style type="text/css"></style>
+        </head>
+        <body>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title></title>
+        </head>
+        <body>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_include_star_selector(self):
+        """test the simplest case"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        p * { color: red }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html_not_included = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html_not_included, result_html)
+
+        expect_html_star_included = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong style="color:red">Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html, include_star_selectors=True)
+        result_html = p.transform()
+
+        compare_html(expect_html_star_included, result_html)
+
+    def test_mixed_pseudo_selectors(self):
+        """mixing pseudo selectors with straight forward selectors"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        p { color: yellow }
+        a { color: blue }
+        a:hover { color: pink }
+        </style>
+        </head>
+        <body>
+        <p>
+          <a href="#">Page</a>
+        </p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">a:hover {color:pink}</style>
+        </head>
+        <body>
+        <p style="color:yellow"><a href="#" style="color:blue">Page</a></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_basic_html_with_pseudo_selector(self):
+        """test the simplest case"""
+
+        html = """
+        <html>
+        <style type="text/css">
+        h1 { border:1px solid black }
+        p { color:red;}
+        p::first-letter { float:left; }
+        </style>
+        <h1 style="font-weight:bolder">Peter</h1>
+        <p>Hej</p>
+        </html>
+        """
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">p::first-letter {float:left}</style>
+        </head>
+        <body>
+        <h1 style="border:1px solid black; font-weight:bolder">Peter</h1>
+        <p style="color:red">Hej</p>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_parse_style_rules(self):
+        p = Premailer('html')  # won't need the html
+        func = p._parse_style_rules
+        rules, leftover = func("""
+        h1, h2 { color:red; }
+        /* ignore
+            this */
+        strong {
+            text-decoration:none
+            }
+        ul li {  list-style: 2px; }
+        a:hover { text-decoration: underline }
+        """, 0)
+
+        # 'rules' is a list, turn it into a dict for
+        # easier assertion testing
+        rules_dict = {}
+        rules_specificity = {}
+        for specificity, k, v in rules:
+            rules_dict[k] = v
+            rules_specificity[k] = specificity
+
+        ok_('h1' in rules_dict)
+        ok_('h2' in rules_dict)
+        ok_('strong' in rules_dict)
+        ok_('ul li' in rules_dict)
+
+        eq_(rules_dict['h1'], 'color:red')
+        eq_(rules_dict['h2'], 'color:red')
+        eq_(rules_dict['strong'], 'text-decoration:none')
+        eq_(rules_dict['ul li'], 'list-style:2px')
+        ok_('a:hover' not in rules_dict)
+
+        # won't need the html
+        p = Premailer('html', exclude_pseudoclasses=True)
+        func = p._parse_style_rules
+        rules, leftover = func("""
+        ul li {  list-style: 2px; }
+        a:hover { text-decoration: underline }
+        """, 0)
+
+        eq_(len(rules), 1)
+        specificity, k, v = rules[0]
+        eq_(k, 'ul li')
+        eq_(v, 'list-style:2px')
+
+        eq_(len(leftover), 1)
+        k, v = leftover[0]
+        eq_((k, v), ('a:hover', 'text-decoration:underline'), (k, v))
+
+    def test_precedence_comparison(self):
+        p = Premailer('html')  # won't need the html
+        rules, leftover = p._parse_style_rules("""
+        #identified { color:blue; }
+        h1, h2 { color:red; }
+        ul li {  list-style: 2px; }
+        li.example { color:green; }
+        strong { text-decoration:none }
+        div li.example p.sample { color:black; }
+        """, 0)
+
+        # 'rules' is a list, turn it into a dict for
+        # easier assertion testing
+        rules_specificity = {}
+        for specificity, k, v in rules:
+            rules_specificity[k] = specificity
+
+        # Last in file wins
+        ok_(rules_specificity['h1'] < rules_specificity['h2'])
+        # More elements wins
+        ok_(rules_specificity['strong'] < rules_specificity['ul li'])
+        # IDs trump everything
+        ok_(rules_specificity['div li.example p.sample'] <
+            rules_specificity['#identified'])
+
+        # Classes trump multiple elements
+        ok_(rules_specificity['ul li'] <
+            rules_specificity['li.example'])
+
+    def test_base_url_fixer(self):
+        """if you leave some URLS as /foo and set base_url to
+        'http://www.google.com' the URLS become 'http://www.google.com/foo'
+        """
+        html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="/images/bar.gif">
+        <img src="cid:images/baz.gif">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>
+        '''
+
+        expect_html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="http://kungfupeople.com/images/foo.jpg">
+        <img src="http://kungfupeople.com/images/bar.gif">
+        <img src="cid:images/baz.gif">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="http://kungfupeople.com/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://kungfupeople.com/subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>'''
+
+        p = Premailer(
+            html,
+            base_url='http://kungfupeople.com',
+            preserve_internal_links=True
+        )
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_base_url_with_path(self):
+        """if you leave some URLS as /foo and set base_url to
+        'http://www.google.com' the URLS become 'http://www.google.com/foo'
+        """
+
+        html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>
+        '''
+
+        expect_html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="http://kungfupeople.com/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="http://kungfupeople.com/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="http://kungfupeople.com/base/subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>'''
+
+        p = Premailer(html, base_url='http://kungfupeople.com/base/',
+                      preserve_internal_links=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_style_block_with_external_urls(self):
+        """
+        From http://github.com/peterbe/premailer/issues/#issue/2
+
+        If you have
+          body { background:url(http://example.com/bg.png); }
+        the ':' inside '://' is causing a problem
+        """
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        body {
+          color:#123;
+          background: url(http://example.com/bg.png);
+          font-family: Omerta;
+        }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body style="background:url(http://exam
+ple.com/bg.png); color:#123; font-family:Omerta">
+        <h1>Hi!</h1>
+        </body>
+        </html>""".replace('exam\nple', 'example')
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_base_url_ignore_links(self):
+        """if you leave some URLS as /foo, set base_url to
+        'http://www.google.com' and set disable_link_rewrites to True, the URLS
+        should not be changed.
+        """
+
+        html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>
+        '''
+
+        expect_html = '''<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="/images/foo.jpg">
+        <img src="http://www.googe.com/photos/foo.jpg">
+        <a href="/home">Home</a>
+        <a href="http://www.peterbe.com">External</a>
+        <a href="http://www.peterbe.com/base/">External 2</a>
+        <a href="subpage">Subpage</a>
+        <a href="#internal_link">Internal Link</a>
+        </body>
+        </html>'''
+
+        p = Premailer(html, base_url='http://kungfupeople.com/base/',
+                      disable_link_rewrites=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_shortcut_function(self):
+        # you don't have to use this approach:
+        #   from premailer import Premailer
+        #   p = Premailer(html, base_url=base_url)
+        #   print p.transform()
+        # You can do it this way:
+        #   from premailer import transform
+        #   print transform(html, base_url=base_url)
+
+        html = '''<html>
+        <head>
+        <style type="text/css">h1{color:#123}</style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        </body>
+        </html>'''
+
+        expect_html = '''<html>
+        <head></head>
+        <body>
+        <h1 style="color:#123">Hi!</h1>
+        </body>
+        </html>'''
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def fragment_in_html(self, fragment, html, fullMessage=False):
+        if fullMessage:
+            message = '"{0}" not in\n{1}'.format(fragment, html)
+        else:
+            message = '"{0}" not in HTML'.format(fragment)
+        ok_(fragment in html, message)
+
+    def test_css_with_pseudoclasses_included(self):
+        "Pick up the pseudoclasses too and include them"
+
+        html = '''<html>
+        <head>
+        <style type="text/css">
+        a.special:link { text-decoration:none; }
+        a { color:red; }
+        a:hover { text-decoration:none; }
+        a,a:hover,
+        a:visited { border:1px solid green; }
+        p::first-letter {float: left; font-size: 300%}
+        </style>
+        </head>
+        <body>
+        <a href="#" class="special">Special!</a>
+        <a href="#">Page</a>
+        <p>Paragraph</p>
+        </body>
+        </html>'''
+
+        p = Premailer(html, exclude_pseudoclasses=False)
+        result_html = p.transform()
+        # because we're dealing with random dicts here we can't predict what
+        # order the style attribute will be written in so we'll look for
+        # things manually.
+        e = '<p style="::first-letter{float:left; font-size:300%}">'\
+            'Paragraph</p>'
+        self.fragment_in_html(e, result_html, True)
+
+        e = 'style="{color:red; border:1px solid green}'
+        self.fragment_in_html(e, result_html)
+        e = ' :visited{border:1px solid green}'
+        self.fragment_in_html(e, result_html)
+        e = ' :hover{text-decoration:none; border:1px solid green}'
+        self.fragment_in_html(e, result_html)
+
+    def test_css_with_pseudoclasses_excluded(self):
+        "Skip things like `a:hover{}` and keep them in the style block"
+
+        html = """<html>
+        <head>
+        <style type="text/css">
+        a { color:red; }
+        a:hover { text-decoration:none; }
+        a,a:hover,
+        a:visited { border:1px solid green; }
+        p::first-letter {float: left; font-size: 300%}
+        </style>
+        </head>
+        <body>
+        <a href="#">Page</a>
+        <p>Paragraph</p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+<head>
+<style type="text/css">a:hover {text-decoration:none}
+a:hover {border:1px solid green}
+a:visited {border:1px solid green}p::first-letter {float:left;font-size:300%}
+</style>
+</head>
+<body>
+<a href="#" style="color:red; border:1px solid green">Page</a>
+<p>Paragraph</p>
+</body>
+</html>"""
+
+        p = Premailer(html, exclude_pseudoclasses=True)
+        result_html = p.transform()
+
+        expect_html = whitespace_between_tags.sub('><', expect_html).strip()
+        result_html = whitespace_between_tags.sub('><', result_html).strip()
+
+        expect_html = re.sub('}\s+', '}', expect_html)
+        result_html = result_html.replace('}\n', '}')
+
+        eq_(expect_html, result_html)
+        # XXX
+
+    def test_css_with_html_attributes(self):
+        """Some CSS styles can be applied as normal HTML attribute like
+        'background-color' can be turned into 'bgcolor'
+        """
+
+        html = """<html>
+        <head>
+        <style type="text/css">
+        td { background-color:red; vertical-align:middle;}
+        p { text-align:center;}
+        table { width:200px; }
+        </style>
+        </head>
+        <body>
+        <p>Text</p>
+        <table>
+          <tr>
+            <td>Cell 1</td>
+            <td>Cell 2</td>
+          </tr>
+        </table>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <p style="text-align:center" align="center">Text</p>
+        <table style="width:200px" width="200">
+          <tr>
+            <td style="background-color:red; vert
+ical-align:middle" bgcolor="red" valign="middle">Cell 1</td>
+            <td style="background-color:red; vert
+ical-align:middle" bgcolor="red" valign="middle">Cell 2</td>
+          </tr>
+        </table>
+        </body>
+        </html>""".replace('vert\nical', 'vertical')
+
+        p = Premailer(html, exclude_pseudoclasses=True)
+        result_html = p.transform()
+
+        expect_html = re.sub('}\s+', '}', expect_html)
+        result_html = result_html.replace('}\n', '}')
+
+        compare_html(expect_html, result_html)
+
+    def test_css_disable_basic_html_attributes(self):
+        """Some CSS styles can be applied as normal HTML attribute like
+        'background-color' can be turned into 'bgcolor'
+        """
+
+        html = """<html>
+        <head>
+        <style type="text/css">
+        td { background-color:red; }
+        p { text-align:center; }
+        table { width:200px; height: 300px; }
+        </style>
+        </head>
+        <body>
+        <p>Text</p>
+        <table>
+          <tr>
+            <td>Cell 1</td>
+            <td>Cell 2</td>
+          </tr>
+        </table>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <p style="text-align:center">Text</p>
+        <table style="height:300px; width:200px">
+          <tr>
+            <td style="background-color:red" bgcolor="red">Cell 1</td>
+            <td style="background-color:red" bgcolor="red">Cell 2</td>
+          </tr>
+        </table>
+        </body>
+        </html>"""
+
+        p = Premailer(
+            html,
+            exclude_pseudoclasses=True,
+            disable_basic_attributes=['align', 'width', 'height']
+        )
+        result_html = p.transform()
+
+        expect_html = re.sub('}\s+', '}', expect_html)
+        result_html = result_html.replace('}\n', '}')
+
+        compare_html(expect_html, result_html)
+
+    def test_apple_newsletter_example(self):
+        # stupidity test
+        import os
+
+        html_file = os.path.join('premailer', 'tests',
+                                 'test-apple-newsletter.html')
+        html = open(html_file).read()
+
+        p = Premailer(html, exclude_pseudoclasses=False,
+                      keep_style_tags=True,
+                      strip_important=False)
+        result_html = p.transform()
+        ok_('<html>' in result_html)
+        ok_('<style media="only screen and (max-device-width: 480px)" '
+            'type="text/css">\n'
+            '* {line-height: normal !important; '
+            '-webkit-text-size-adjust: 125%}\n'
+            '</style>' in result_html)
+
+    def test_mailto_url(self):
+        """if you use URL with mailto: protocol, they should stay as mailto:
+        when baseurl is used
+        """
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <a href="mailto:e-mail@example.com">e-mail@example.com</a>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <a href="mailto:e-mail@example.com">e-mail@example.com</a>
+        </body>
+        </html>"""
+
+        p = Premailer(html, base_url='http://kungfupeople.com')
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_tel_url(self):
+        """if you use URL with tel: protocol, it should stay as tel:
+        when baseurl is used
+        """
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <a href="tel:202-555-0113">202-555-0113</a>
+        </body>
+        </html>"""
+
+        p = Premailer(html, base_url='http://kungfupeople.com')
+        result_html = p.transform()
+
+        compare_html(result_html, html)
+
+    def test_uppercase_margin(self):
+        """Option to comply with outlook.com
+
+        https://emailonacid.com/blog/article/email-development/outlook.com-does-support-margins
+        """
+
+        html = """<html>
+<head>
+<title>Title</title>
+</head>
+<style>
+h1 {margin: 0}
+h2 {margin-top:0;margin-bottom:0;margin-left:0;margin-right:0}
+</style>
+<body>
+<h1>a</h1>
+<h2>
+b
+</h2>
+</body>
+</html>"""
+
+        expect_html = """<html>
+<head>
+<title>Title</title>
+</head>
+<body>
+<h1 style="Margin:0">a</h1>
+<h2 style="Margin-bottom:0; Margin-left:0; Margin-right:0; Margin-top:0">
+b
+</h2>
+</body>
+</html>"""
+
+        p = Premailer(html, capitalize_float_margin=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_strip_important(self):
+        """Get rid of !important. Makes no sense inline."""
+        html = """<html>
+        <head>
+        <style type="text/css">
+        p {
+            height:100% !important;
+            width:100% !important;
+        }
+        </style>
+        </head>
+        <body>
+        <p>Paragraph</p>
+        </body>
+        </html>
+        """
+        expect_html = """<html>
+<head>
+</head>
+<body>
+<p style="height:100%; width:100%" height="100%" width="100%">Paragraph</p>
+</body>
+</html>"""
+
+        p = Premailer(html, strip_important=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_inline_wins_over_external(self):
+        html = """<html>
+        <head>
+        <style type="text/css">
+        div {
+            text-align: left;
+        }
+        /* This tests that a second loop for the same style still doesn't
+         * overwrite it. */
+        div {
+            text-align: left;
+        }
+        </style>
+        </head>
+        <body>
+        <div style="text-align:right">Some text</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="text-align:right" align="right">Some text</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_last_child(self):
+        html = """<html>
+        <head>
+        <style type="text/css">
+        div {
+            text-align: right;
+        }
+        div:last-child {
+            text-align: left;
+        }
+        </style>
+        </head>
+        <body>
+        <div>First child</div>
+        <div>Last child</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="text-align:right" align="right">First child</div>
+        <div style="text-align:left" align="left">Last child</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_last_child_exclude_pseudo(self):
+        html = """<html>
+        <head>
+        <style type="text/css">
+        div {
+            text-align: right;
+        }
+        div:last-child {
+            text-align: left;
+        }
+        </style>
+        </head>
+        <body>
+        <div>First child</div>
+        <div>Last child</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="text-align:right" align="right">First child</div>
+        <div style="text-align:left" align="left">Last child</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, exclude_pseudoclasses=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_mediaquery(self):
+        html = """<html>
+        <head>
+        <style type="text/css">
+        div {
+            text-align: right;
+        }
+        @media print{
+            div {
+                text-align: center;
+                color: white;
+            }
+            div {
+                font-size: 999px;
+            }
+        }
+        </style>
+        </head>
+        <body>
+        <div>First div</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">@media print {
+        div {
+            text-align: center !important;
+            color: white !important
+            }
+        div {
+            font-size: 999px !important
+            }
+        }</style>
+        </head>
+        <body>
+        <div style="text-align:right" align="right">First div</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, strip_important=False)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_child_selector(self):
+        html = """<html>
+        <head>
+        <style type="text/css">
+        body > div {
+            text-align: right;
+        }
+        </style>
+        </head>
+        <body>
+        <div>First div</div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div style="text-align:right" align="right">First div</div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_doctype(self):
+        html = (
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" '
+            '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+            """<html>
+            <head>
+            </head>
+            <body>
+            </body>
+            </html>"""
+        )
+
+        expect_html = (
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" '
+            '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+            """<html>
+            <head>
+            </head>
+            <body>
+            </body>
+            </html>"""
+        )
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_prefer_inline_to_class(self):
+        html = """<html>
+        <head>
+        <style>
+        .example {
+            color: black;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="example" style="color:red"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="example" style="color:red"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_favour_rule_with_element_over_generic(self):
+        html = """<html>
+        <head>
+        <style>
+        div.example {
+            color: green;
+        }
+        .example {
+            color: black;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="example"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="example" style="color:green"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_favour_rule_with_class_over_generic(self):
+        html = """<html>
+        <head>
+        <style>
+        div.example {
+            color: green;
+        }
+        div {
+            color: black;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="example"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="example" style="color:green"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_favour_rule_with_id_over_others(self):
+        html = """<html>
+        <head>
+        <style>
+        #identified {
+            color: green;
+        }
+        div.example {
+            color: black;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="example" id="identified"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="example" id="identified" style="color:green"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_favour_rule_with_important_over_others(self):
+        html = """<html>
+        <head>
+        <style>
+        .makeblue {
+            color: blue !important;
+            font-size: 12px;
+        }
+        #id {
+            color: green;
+            font-size: 22px;
+        }
+        div.example {
+            color: black;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="example makeblue" id="id"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+<head>
+</head>
+<body>
+<div class="example makeblue" id="id" style="font-size:22px; color:blue"></div>
+</body>
+</html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_multiple_style_elements(self):
+        """Asserts that rules from multiple style elements
+        are inlined correctly."""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        <style type="text/css">
+        h1, h2 { color:green; }
+        p {
+            font-size:120%
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 style="color:green">Hi!</h1>
+        <p style="font-size:120%"><strong style="text-deco
+ration:none">Yes!</strong></p>
+        </body>
+        </html>""".replace('deco\nration', 'decoration')
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_style_attribute_specificity(self):
+        """Stuff already in style attributes beats style tags."""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1 { color: pink }
+        h1.foo { color: blue }
+        </style>
+        </head>
+        <body>
+        <h1 class="foo" style="color: green">Hi!</h1>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 class="foo" style="color:green">Hi!</h1>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_ignore_style_elements_with_media_attribute(self):
+        """Asserts that style elements with media attributes other than
+        'screen' are ignored."""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+            h1, h2 { color:red; }
+            strong {
+                text-decoration:none
+            }
+        </style>
+        <style type="text/css" media="screen">
+            h1, h2 { color:green; }
+            p {
+                font-size:16px;
+                }
+        </style>
+        <style type="text/css" media="only screen and (max-width: 480px)">
+            h1, h2 { color:orange; }
+            p {
+                font-size:120%;
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css" media="only screen and (max-width: 480px)">
+            h1, h2 { color:orange; }
+            p {
+                font-size:120%;
+            }
+        </style>
+        </head>
+        <body>
+        <h1 style="color:green">Hi!</h1>
+        <p style="font-size:16px"><strong style="text-deco
+ration:none">Yes!</strong></p>
+        </body>
+        </html>""".replace('deco\nration', 'decoration')
+
+        p = Premailer(html)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_leftover_important(self):
+        """Asserts that leftover styles should be marked as !important."""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        a { color: red; }
+        a:hover { color: green; }
+        a:focus { color: blue !important; }
+        </style>
+        </head>
+        <body>
+        <a href="#">Hi!</a>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        a { color: red; }
+        a:hover { color: green; }
+        a:focus { color: blue !important; }
+        </style>
+        </head>
+        <body>
+        <a href="#" style="color:red">Hi!</a>
+        </body>
+        </html>"""
+
+        p = Premailer(html,
+                      keep_style_tags=True,
+                      strip_important=False)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_basic_xml(self):
+        """Test the simplest case with xml"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        img { border: none; }
+        </style>
+        </head>
+        <body>
+        <img src="test.png" alt="test"/>
+        </body>
+        </html>
+        """
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <img src="test.png" alt="test" style="border:none"/>
+        </body>
+        </html>
+        """
+
+        p = Premailer(html, method="xml")
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_broken_xml(self):
+        """Test the simplest case with xml"""
+
+        html = """<html>
+        <head>
+        <title>Title
+        <style type="text/css">
+        img { border: none; }
+        </style>
+        </head>
+        <body>
+        <img src="test.png" alt="test"/>
+        </body>
+        """
+
+        p = Premailer(html, method="xml")
+        assert_raises(
+            XMLSyntaxError,
+            p.transform,
+        )
+
+    def test_xml_cdata(self):
+        """Test that CDATA is set correctly on remaining styles"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        span:hover > a { background: red; }
+        </style>
+        </head>
+        <body>
+        <span><a>Test</a></span>
+        </body>
+        </html>
+        """
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">/*<![CDATA[*/span:hover > a {back
+ground:red}/*]]>*/</style>
+        </head>
+        <body>
+        <span><a>Test</a></span>
+        </body>
+        </html>
+        """.replace('back\nground', 'background')
+
+        p = Premailer(html, method="xml")
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_command_line_fileinput_from_stdin(self):
+        html = '<style>h1 { color:red; }</style><h1>Title</h1>'
+        expect_html = """
+        <html>
+        <head></head>
+        <body><h1 style="color:red">Title</h1></body>
+        </html>
+        """
+
+        with provide_input(html) as (out, err):
+            main([])
+        result_html = out.getvalue().strip()
+
+        compare_html(expect_html, result_html)
+
+    def test_command_line_fileinput_from_argument(self):
+        with captured_output() as (out, err):
+            main([
+                '-f',
+                'premailer/tests/test-apple-newsletter.html',
+                '--disable-basic-attributes=bgcolor'
+            ])
+
+        result_html = out.getvalue().strip()
+
+        ok_('<html>' in result_html)
+        ok_('<style media="only screen and (max-device-width: 480px)" '
+            'type="text/css">\n'
+            '* {line-height: normal !important; '
+            '-webkit-text-size-adjust: 125%}\n'
+            '</style>' in result_html)
+
+    def test_command_line_preserve_style_tags(self):
+        with captured_output() as (out, err):
+            main([
+                '-f',
+                'premailer/tests/test-issue78.html',
+                '--preserve-style-tags',
+                '--external-style=premailer/tests/test-external-styles.css',
+            ])
+
+        result_html = out.getvalue().strip()
+
+        expect_html = """
+        <html>
+        <head>
+        <style type="text/css">h1 {
+          color: blue;
+        }
+        h2 {
+          color: green;
+        }
+        a {
+          color: pink;
+        }
+        a:hover {
+          color: purple;
+        }
+        </style>
+        <link rel="alternate" type="applic
+ation/rss+xml" title="RSS" href="/rss.xml">
+        <style type="text/css">
+        .yshortcuts a {border-bottom: none !important;}
+        @media screen and (max-width: 600px) {
+            table[class="container"] {
+                width: 100% !important;
+            }
+        }
+        /* Even comments should be preserved when the
+           keep_style_tags flag is set */
+        p {font-size:12px;}
+        </style>
+        <style type="text/css">h1 {
+          color: brown;
+        }
+        h2::after {
+          content: "";
+          display: block;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                font-size: 12px;
+            }
+        }
+        </style>
+        </head>
+        <body>
+        <h1 style="color:brown">h1</h1>
+        <p style="font-size:12px"><a href="" style="{color:pink} :hover{col
+or:purple}">html</a></p>
+        </body>
+        </html>
+        """.replace('col\nor', 'color').replace('applic\nation', 'application')
+
+        compare_html(expect_html, result_html)
+
+        # for completeness, test it once without
+        with captured_output() as (out, err):
+            main([
+                '-f',
+                'premailer/tests/test-issue78.html',
+                '--external-style=premailer/tests/test-external-styles.css',
+            ])
+
+        result_html = out.getvalue().strip()
+        expect_html = """
+        <html>
+        <head>
+        <link rel="alternate" type="applic
+ation/rss+xml" title="RSS" href="/rss.xml">
+        <style type="text/css">@media screen and (max-width: 600px) {
+            table[class="container"] {
+                width: 100% !important
+                }
+            }</style>
+        <style type="text/css">@media all and (max-width: 320px) {
+            h1 {
+                font-size: 12px !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">h1</h1>
+        <p style="font-size:12px"><a href="" style="{color:pink} :hover{co
+lor:purple}">html</a></p>
+        </body>
+        </html>
+        """.replace('co\nlor', 'color').replace('applic\nation', 'application')
+
+        compare_html(expect_html, result_html)
+
+    def test_multithreading(self):
+        """The test tests thread safety of merge_styles function which employs
+        thread non-safe cssutils calls.
+        The test would fail if merge_styles would have not been thread-safe """
+
+        import threading
+        import logging
+        THREADS = 30
+        REPEATS = 100
+
+        class RepeatMergeStylesThread(threading.Thread):
+            """The thread is instantiated by test and run multiple
+            times in parallel."""
+            exc = None
+
+            def __init__(self, old, new, class_):
+                """The constructor just stores merge_styles parameters"""
+                super(RepeatMergeStylesThread, self).__init__()
+                self.old, self.new, self.class_ = old, new, class_
+
+            def run(self):
+                """Calls merge_styles in a loop and sets exc attribute
+                if merge_styles raises an exception."""
+                for _ in range(0, REPEATS):
+                    try:
+                        merge_styles(self.old, self.new, self.class_)
+                    except Exception as e:
+                        logging.exception("Exception in thread %s", self.name)
+                        self.exc = e
+
+        inline_style = 'background-color:#ffffff;'
+        new = 'background-color:#dddddd;'
+        class_ = ''
+
+        # start multiple threads concurrently; each
+        # calls merge_styles many times
+        threads = [
+            RepeatMergeStylesThread(
+                inline_style,
+                [csstext_to_pairs(new)],
+                [class_]
+            )
+            for _ in range(0, THREADS)
+        ]
+        for t in threads:
+            t.start()
+
+        # wait until all threads are done
+        for t in threads:
+            t.join()
+
+        # check if any thread raised exception while in merge_styles call
+        exceptions = [t.exc for t in threads if t.exc is not None]
+        eq_(exceptions, [])
+
+    def test_external_links(self):
+        """Test loading stylesheets via link tags"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1 { color:red; }
+        h3 { color:yellow; }
+        </style>
+        <link href="premailer/tests/test-external-links.css" rel="style
+sheet" type="text/css">
+        <link rel="alternate" type="applic
+ation/rss+xml" title="RSS" href="/rss.xml">
+        <style type="text/css">
+        h1 { color:orange; }
+        </style>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        <h3>Test</h3>
+        <a href="#">Link</a>
+        </body>
+        </html>""".replace(
+            'applic\naction', 'application'
+        ).replace('style\nsheet', 'stylesheet')
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">a:hover {color:purple !important}</style>
+        <link rel="alternate" type="applic
+ation/rss+xml" title="RSS" href="/rss.xml">
+        </head>
+        <body>
+        <h1 style="color:orange">Hello</h1>
+        <h2 style="color:green">World</h2>
+        <h3 style="color:yellow">Test</h3>
+        <a href="#" style="color:pink">Link</a>
+        </body>
+        </html>""".replace('applic\naction', 'application')
+
+        p = Premailer(
+            html,
+            strip_important=False
+        )
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_external_links_unfindable(self):
+        """Test loading stylesheets that can't be found"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1 { color:red; }
+        h3 { color:yellow; }
+        </style>
+        <link href="premailer/xxxx.css" rel="stylesheet" type="text/css">
+        <style type="text/css">
+        h1 { color:orange; }
+        </style>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        <h3>Test</h3>
+        <a href="#">Link</a>
+        </body>
+        </html>"""
+
+        p = Premailer(
+            html,
+            strip_important=False
+        )
+        assert_raises(
+            ExternalNotFoundError,
+            p.transform,
+        )
+
+    def test_external_styles_and_links(self):
+        """Test loading stylesheets via both the 'external_styles'
+        argument and link tags"""
+
+        html = """<html>
+        <head>
+        <link href="test-external-links.css" rel="stylesheet" type="text/css">
+        <style type="text/css">
+        h1 { color: red; }
+        </style>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">a:hover {color:purple !important}</style>
+        <style type="text/css">h2::after {cont
+ent:"" !important;display:block !important}
+        @media all and (max-width: 320px) {
+            h1 {
+                font-size: 12px !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>""".replace('cont\nent', 'content')
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            external_styles='test-external-styles.css',
+            base_path='premailer/tests/')
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    @mock.patch('premailer.premailer.requests')
+    def test_load_external_url(self, mocked_requests):
+        'Test premailer.premailer.Premailer._load_external_url'
+        faux_response = 'This is not a response'
+        faux_uri = 'https://example.com/site.css'
+        mocked_requests.get.return_value = MockResponse(faux_response)
+        p = premailer.premailer.Premailer('<p>A paragraph</p>')
+        r = p._load_external_url(faux_uri)
+
+        mocked_requests.get.assert_called_once_with(faux_uri)
+        eq_(faux_response, r)
+
+    def test_css_text(self):
+        """Test handling css_text passed as a string"""
+
+        html = """<html>
+        <head>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">@media all and (max-width: 320px) {
+            h1 {
+                color: black !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>"""
+
+        css_text = """
+        h1 {
+            color: brown;
+        }
+        h2 {
+            color: green;
+        }
+        a {
+            color: pink;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                color: black;
+            }
+        }
+
+        """
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            css_text=[css_text])
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_css_text_with_only_body_present(self):
+        """Test handling css_text passed as a string when no <html> or
+        <head> is present"""
+
+        html = """<body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>"""
+
+        expect_html = """<html>
+        <head>
+        <style type="text/css">@media all and (max-width: 320px) {
+            h1 {
+                color: black !important
+                }
+            }</style>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>"""
+
+        css_text = """
+        h1 {
+            color: brown;
+        }
+        h2 {
+            color: green;
+        }
+        a {
+            color: pink;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                color: black;
+            }
+        }
+        """
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            css_text=css_text)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_css_disable_leftover_css(self):
+        """Test handling css_text passed as a string when no <html> or
+        <head> is present"""
+
+        html = """<body>
+        <h1>Hello</h1>
+        <h2>Hello</h2>
+        <a href="">Hello</a>
+        </body>"""
+
+        expect_html = """<html>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:green">Hello</h2>
+        <a href="" style="color:pink">Hello</a>
+        </body>
+        </html>"""
+
+        css_text = """
+        h1 {
+            color: brown;
+        }
+        h2 {
+            color: green;
+        }
+        a {
+            color: pink;
+        }
+        @media all and (max-width: 320px) {
+            h1 {
+                color: black;
+            }
+        }
+        """
+
+        p = Premailer(
+            html,
+            strip_important=False,
+            css_text=css_text,
+            disable_leftover_css=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    @staticmethod
+    def mocked_urlopen(url):
+        'The standard "response" from the "server".'
+        retval = ''
+        if 'style1.css' in url:
+            retval = "h1 { color: brown }"
+        elif 'style2.css' in url:
+            retval = "h2 { color: pink }"
+        elif 'style3.css' in url:
+            retval = "h3 { color: red }"
+        return retval
+
+    @mock.patch.object(Premailer, '_load_external_url')
+    def test_external_styles_on_http(self, mocked_pleu):
+        """Test loading styles that are genuinely external"""
+
+        html = """<html>
+        <head>
+        <link href="https://www.com/style1.css" rel="stylesheet">
+        <link href="//www.com/style2.css" rel="stylesheet">
+        <link href="//www.com/style3.css" rel="stylesheet">
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        <h3>World</h3>
+        </body>
+        </html>"""
+        mocked_pleu.side_effect = self.mocked_urlopen
+        p = Premailer(html)
+        result_html = p.transform()
+
+        # Expected values are tuples of the positional values (as another
+        # tuple) and the ketword arguments (which are all null), hence the
+        # following Lisp-like explosion of brackets and commas.
+        expected_args = [(('https://www.com/style1.css',),),
+                         (('http://www.com/style2.css',),),
+                         (('http://www.com/style3.css',),)]
+        eq_(expected_args, mocked_pleu.call_args_list)
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:pink">World</h2>
+        <h3 style="color:red">World</h3>
+        </body>
+        </html>"""
+        compare_html(expect_html, result_html)
+
+    @mock.patch.object(Premailer, '_load_external_url')
+    def test_external_styles_on_https(self, mocked_pleu):
+        """Test loading styles that are genuinely external"""
+
+        html = """<html>
+        <head>
+        <link href="https://www.com/style1.css" rel="stylesheet">
+        <link href="//www.com/style2.css" rel="stylesheet">
+        <link href="/style3.css" rel="stylesheet">
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        <h3>World</h3>
+        </body>
+        </html>"""
+
+        mocked_pleu.side_effect = self.mocked_urlopen
+        p = Premailer(html, base_url='https://www.peterbe.com')
+        result_html = p.transform()
+
+        expected_args = [(('https://www.com/style1.css',),),
+                         (('https://www.com/style2.css',),),
+                         (('https://www.peterbe.com/style3.css',),)]
+        eq_(expected_args, mocked_pleu.call_args_list)
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        <h2 style="color:pink">World</h2>
+        <h3 style="color:red">World</h3>
+        </body>
+        </html>"""
+        compare_html(expect_html, result_html)
+
+    @mock.patch.object(Premailer, '_load_external_url')
+    def test_external_styles_with_base_url(self, mocked_pleu):
+        """Test loading styles that are genuinely external if you use
+        the base_url"""
+
+        html = """<html>
+        <head>
+        <link href="style.css" rel="stylesheet" type="text/css">
+        </head>
+        <body>
+        <h1>Hello</h1>
+        </body>
+        </html>"""
+        mocked_pleu.return_value = "h1 { color: brown }"
+        p = Premailer(html, base_url='http://www.peterbe.com/')
+        result_html = p.transform()
+        expected_args = [(('http://www.peterbe.com/style.css',),), ]
+        eq_(expected_args, mocked_pleu.call_args_list)
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <h1 style="color:brown">Hello</h1>
+        </body>
+        </html>"""
+        compare_html(expect_html, result_html)
+
+    def test_disabled_validator(self):
+        """test disabled_validator"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { fo:bar; }
+        strong {
+            color:baz;
+            text-decoration:none;
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 style="fo:bar">Hi!</h1>
+        <p><strong style="color:baz; text-decoration:none">Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_comments_in_media_queries(self):
+        """CSS comments inside a media query block should not be a problem"""
+        html = """<!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Document</title>
+            <style>
+            @media screen {
+                /* comment */
+            }
+            </style>
+        </head>
+        <body></body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        result_html = p.transform()
+        ok_('/* comment */' in result_html)
+
+    def test_fontface_selectors_with_no_selectortext(self):
+        """
+        @font-face selectors are weird.
+        This is a fix for https://github.com/peterbe/premailer/issues/71
+        """
+        html = """<!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Document</title>
+            <style>
+            @font-face {
+                font-family: 'Garamond';
+                src:
+                    local('Garamond'),
+                    local('Garamond-Regular'),
+                    url('Garamond.ttf') format('truetype');
+                    font-weight: normal;
+                    font-style: normal;
+            }
+            </style>
+        </head>
+        <body></body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        p.transform()  # it should just work
+
+    def test_keyframe_selectors(self):
+        """
+        keyframes shouldn't be a problem.
+        """
+        html = """<!doctype html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>Document</title>
+            <style>
+            @keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+
+            /* Firefox */
+            @-moz-keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+
+            /* Safari and Chrome */
+            @-webkit-keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+
+            /* Internet Explorer */
+            @-ms-keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+
+            /* Opera */
+            @-o-keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+            </style>
+        </head>
+        <body></body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        p.transform()  # it should just work
+
+    def test_capture_cssutils_logging(self):
+        """you can capture all the warnings, errors etc. from cssutils
+        with your own logging. """
+        html = """<!doctype html>
+        <html>
+        <head>
+            <meta charset="UTF-8">
+            <title>Document</title>
+            <style>
+            @keyframes fadein {
+                from { opacity: 0; }
+                to   { opacity: 1; }
+            }
+            </style>
+        </head>
+        <body></body>
+        </html>"""
+
+        mylog = StringIO()
+        myhandler = logging.StreamHandler(mylog)
+        p = Premailer(
+            html,
+            cssutils_logging_handler=myhandler,
+        )
+        p.transform()  # it should work
+        eq_(
+            mylog.getvalue(),
+            'CSSStylesheet: Unknown @rule found. [2:13: @keyframes]\n'
+        )
+
+        # only log errors now
+        mylog = StringIO()
+        myhandler = logging.StreamHandler(mylog)
+        p = Premailer(
+            html,
+            cssutils_logging_handler=myhandler,
+            cssutils_logging_level=logging.ERROR,
+        )
+        p.transform()  # it should work
+        eq_(mylog.getvalue(), '')
+
+    def test_type_test(self):
+        """test the correct type is returned"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 { color:red; }
+        strong {
+            text-decoration:none
+            }
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p><strong>Yes!</strong></p>
+        </body>
+        </html>"""
+
+        p = Premailer(html)
+        result = p.transform()
+        eq_(type(result), type(""))
+
+        html = fromstring(html)
+        etree_type = type(html)
+
+        p = Premailer(html)
+        result = p.transform()
+        ok_(type(result) != etree_type)
+
+    def test_ignore_some_inline_stylesheets(self):
+        """test that it's possible to put a `data-premailer="ignore"`
+        attribute on a <style> tag and it gets left alone (except that
+        the attribute gets removed)"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1 { color:red; }
+        </style>
+        <style type="text/css" data-premailer="ignore">
+        h1 { color:blue; }
+        </style>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1 { color:blue; }
+        </style>
+        </head>
+        <body>
+        <h1 style="color:red">Hello</h1>
+        <h2>World</h2>
+        </body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    @mock.patch('premailer.premailer.warnings')
+    def test_ignore_some_incorrectly(self, warnings_mock):
+        """You can put `data-premailer="ignore"` but if the attribute value
+        is something we don't recognize you get a warning"""
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css" data-premailer="blah">
+        h1 { color:blue; }
+        </style>
+        </head>
+        <body>
+        <h1>Hello</h1>
+        <h2>World</h2>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        <title>Title</title>
+        </head>
+        <body>
+        <h1 style="color:blue">Hello</h1>
+        <h2>World</h2>
+        </body>
+        </html>"""
+
+        p = Premailer(html, disable_validation=True)
+        result_html = p.transform()
+        warnings_mock.warn.assert_called_with(
+            "Unrecognized data-premailer attribute ('blah')"
+        )
+
+        compare_html(expect_html, result_html)
+
+    def test_ignore_some_external_stylesheets(self):
+        """test that it's possible to put a `data-premailer="ignore"`
+        attribute on a <link> tag and it gets left alone (except that
+        the attribute gets removed)"""
+
+        # Know thy fixtures!
+        # The test-external-links.css has a `h1{color:blue}`
+        # And the test-external-styles.css has a `h1{color:brown}`
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <link href="premailer/tests/test-external-links.css"
+         rel="stylesheet" type="text/css">
+        <link data-premailer="ignore"
+          href="premailer/tests/test-external-styles.css"
+          rel="stylesheet" type="text/css">
+        </head>
+        <body>
+        <h1>Hello</h1>
+        </body>
+        </html>"""
+
+        # Note that the `test-external-links.css` gets converted to a inline
+        # style sheet.
+        expect_html = """<html>
+<head>
+<title>Title</title>
+<style type="text/css">a:hover {color:purple}</style>
+<link href="premailer/tests/test-external-styles.css" rel="style
+sheet" type="text/css">
+</head>
+<body>
+<h1 style="color:blue">Hello</h1>
+</body>
+</html>""".replace('style\nsheet', 'stylesheet')
+
+        p = Premailer(html, disable_validation=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_turnoff_cache_works_as_expected(self):
+        html = """<html>
+        <head>
+        <style>
+        .color {
+            color: green;
+        }
+        div.example {
+            font-size: 10px;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="color example"></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="color example" style="color:green; font-size:10px"></div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, cache_css_parsing=False)
+        self.assertFalse(p.cache_css_parsing)
+        # run one time first
+        p.transform()
+        result_html = p.transform()
+
+        compare_html(expect_html, result_html)
+
+    def test_links_without_protocol(self):
+        """If you the base URL is set to https://example.com and your html
+        contains <img src="//otherdomain.com/">... then the URL to point to
+        is "https://otherdomain.com/" not "https://example.com/file.css"
+        """
+        html = """<html>
+        <head>
+        </head>
+        <body>
+        <img src="//example.com">
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <img src="{protocol}://example.com">
+        </body>
+        </html>"""
+
+        p = Premailer(html, base_url='https://www.peterbe.com')
+        result_html = p.transform()
+        compare_html(expect_html.format(protocol="https"), result_html)
+
+        p = Premailer(html, base_url='http://www.peterbe.com')
+        result_html = p.transform()
+        compare_html(expect_html.format(protocol="http"), result_html)
+
+        # Because you can't set a base_url without a full protocol
+        p = Premailer(html, base_url='www.peterbe.com')
+        assert_raises(ValueError, p.transform)
+
+    def test_align_float_images(self):
+
+        html = """<html>
+        <head>
+        <title>Title</title>
+        <style>
+        .floatright {
+            float: right;
+        }
+        </style>
+        </head>
+        <body>
+        <p><img src="/images/left.jpg" style="float: left"> text
+           <img src="/r.png" class="floatright"> text
+           <img src="/images/nofloat.gif"> text
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+<head>
+<title>Title</title>
+</head>
+<body>
+<p><img src="/images/left.jpg" style="float: left" align="left"> text
+   <img src="/r.png" class="floatright" style="float:right" align="right"> text
+   <img src="/images/nofloat.gif"> text
+</p>
+</body>
+</html>"""
+
+        p = Premailer(html, align_floating_images=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_remove_unset_properties(self):
+        html = """<html>
+        <head>
+        <style>
+        div {
+            color: green;
+        }
+        span {
+            color: blue;
+        }
+        span.nocolor {
+            color: unset;
+        }
+        </style>
+        </head>
+        <body>
+        <div class="color"><span class="nocolor"></span></div>
+        </body>
+        </html>"""
+
+        expect_html = """<html>
+        <head>
+        </head>
+        <body>
+        <div class="color" style="color:green"><span class="nocolor"></span>
+        </div>
+        </body>
+        </html>"""
+
+        p = Premailer(html, remove_unset_properties=True)
+        self.assertTrue(p.remove_unset_properties)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_six_color(self):
+        r = Premailer.six_color('#cde')
+        e = '#ccddee'
+        self.assertEqual(e, r)
+
+    def test_3_digit_color_expand(self):
+        'Are 3-digit color values expanded into 6-digits for IBM Notes'
+        html = """<html>
+    <style>
+        body {background-color: #fe5;}
+        p {background-color: #123456;}
+        h1 {color: #f0df0d;}
+    </style>
+    <body>
+        <h1>color test</h1>
+        <p>
+            This is a test of color handling.
+        </p>
+    </body>
+</html>"""
+        expect_html = """<html>
+    <head>
+    </head>
+    <body style="background-color:#fe5" bgcolor="#ffee55">
+        <h1 style="color:#f0df0d">color test</h1>
+        <p style="background-color:#123456" bgcolor="#123456">
+            This is a test of color handling.
+        </p>
+    </body>
+</html>"""
+        p = Premailer(html, remove_unset_properties=True)
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_inline_important(self):
+        'Are !important tags preserved inline.'
+
+        html = """<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <style type="text/css">.something { display:none !important; }</style>
+  <div class="something">blah</div>
+</body>
+</html>"""
+
+        expect_html = """<html>
+<head>
+  <title></title>
+</head>
+<body>
+  <style type="text/css">.something { display:none !important; }</style>
+  <div class="something" style="display:none !important">blah</div>
+</body>
+</html>"""
+        p = Premailer(
+            html,
+            remove_classes=False,
+            keep_style_tags=True,
+            strip_important=False
+        )
+        result_html = p.transform()
+        compare_html(expect_html, result_html)
+
+    def test_pseudo_selectors_without_selector(self):
+        """Happens when you have pseudo selectors without an actual selector.
+        Which means it's not possible to find it in the DOM.
+
+        For example:
+
+           <style>
+           :before{box-sizing:inherit}
+           </style>
+
+        Semantic-UI uses this in its normalizer.
+
+        Original issue: https://github.com/peterbe/premailer/issues/184
+        """
+
+        html = """
+            <html>
+            <style>
+                 *,:after,:before{box-sizing:inherit}
+                h1{ border: 1px solid blue}
+                h1:hover {border: 1px solid green}
+
+            </style>
+            <h1>Hey</h1>
+            </html>
+        """
+
+        expect_html = """
+<html>
+    <head>
+    <style>
+         *,:after,:before{box-sizing:inherit}
+        h1{ border: 1px solid blue}
+        h1:hover {border: 1px solid green}
+
+    </style>
+    </head>
+    <body>
+    <h1 style="{border:1px solid blue} :hover{border:1px solid green}">Hey</h1>
+    </body>
+</html>
+        """
+        p = Premailer(
+            html,
+            exclude_pseudoclasses=False,
+            keep_style_tags=True,
+        )
+        result_html = p.transform()
+        compare_html(expect_html, result_html)

--- a/premailer/tests/test_utils.py
+++ b/premailer/tests/test_utils.py
@@ -1,0 +1,19 @@
+import unittest
+
+from premailer.premailer import capitalize_float_margin
+
+
+class UtilsTestCase(unittest.TestCase):
+    def testcapitalize_float_margin(self):
+        self.assertEqual(
+            capitalize_float_margin('margin:1em'),
+            'Margin:1em')
+        self.assertEqual(
+            capitalize_float_margin('margin-left:1em'),
+            'Margin-left:1em')
+        self.assertEqual(
+            capitalize_float_margin('float:right;'),
+            'Float:right;')
+        self.assertEqual(
+            capitalize_float_margin('float:right;color:red;margin:0'),
+            'Float:right;color:red;Margin:0')

--- a/tests/preprocess_cssless_data/basic_string_expected.html
+++ b/tests/preprocess_cssless_data/basic_string_expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" style='font-family: "DejaVu Sans", arial, sans-serif;font-size: 16pt'>
+<html lang="en" dir="ltr" style='font-family:"DejaVu Sans", arial, sans-serif;font-size: 16.0pt'>
 <head>
 <title>std::basic_string - cppreference.com</title>
 <meta charset="UTF-8">
@@ -19,7 +19,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 }</script>
 <!--[if lt IE 7]><style type="text/css">body{behavior:url("/mwiki/skins/cppreference2/csshover.min.htc")}</style><![endif]-->
 </head>
-<body style='font-family: "DejaVu Sans", arial, sans-serif;font-size: 16pt;background-color: white' bgcolor="white">
+<body style='font-family:"DejaVu Sans", arial, sans-serif;font-size: 16.0pt;background-color:white' bgcolor="white">
         <!-- header -->
         <!-- /header -->
         <!-- content -->
@@ -27,8 +27,8 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
             <div id="content" style="line-height:1.2em; position:static; margin:0; width:48.75em; padding-top:32px" width="48.75em">
                 <a id="top"></a>
                 <!-- firstHeading -->
-                <h1 id="firstHeading" style="font-size: 32pt">
-<span style="font-size: 22.4pt;line-height: 130%">std::</span>basic_string</h1>
+                <h1 id="firstHeading" style="font-size: 32.0pt">
+<span style="font-size: 22.4pt;line-height:130%">std::</span>basic_string</h1>
                 <!-- /firstHeading -->
                 <!-- bodyContent -->
                 <div id="bodyContent" style="line-height:1.2em; position:static">
@@ -39,25 +39,25 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
                                                             <!-- bodycontent -->
                     <div id="mw-content-text" lang="en" dir="ltr">
 <div style="display:inline-block; height:1.72em; left:0; position:absolute; top:0" height="1.72em">
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-inv-tab.png);background-position: left bottom;background-repeat: no-repeat;width: 8px;border-bottom-width: 0" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><a href="../../cpp.html" title="cpp"> C++</a></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><a href="../string.html" title="cpp/string"> Strings library</a></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><strong style="font-weight:bold"><tt style='font-family:"DejaVu Sans Mono", courier, monospace'>std::basic_string</tt></strong></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px;border-bottom-width: 0" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-inv-tab.png);background-position:left bottom;background-repeat:no-repeat;width:8px;border-bottom-width:0" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><a href="../../cpp.html" title="cpp"> C++</a></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><a href="../string.html" title="cpp/string"> Strings library</a></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><strong style="font-weight:bold"><tt style='font-family:"DejaVu Sans Mono", courier, monospace'>std::basic_string</tt></strong></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px;border-bottom-width:0" height="100%" width="8"> </div>
 </div>
 <table style="background-color:transparent; border-spacing:0; display:block; padding:0.5em 0"><tbody>
 <tr>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../header/string.html" title="cpp/header/string">&lt;string&gt;</a></code>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../header/string.html" title="cpp/header/string">&lt;string&gt;</a></code>
  </div>
 </td>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"></td>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"></td>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"></td>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"></td>
 </tr>
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-size: 16pt;padding: 0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">template</span><span style="color:#000080">&lt;</span> <br>
+<td style="font-size: 16.0pt;padding:0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">template</span><span style="color:#000080">&lt;</span> <br>
 <p style="line-height:1.2em">    <span style="color:#00d">class</span> CharT, <br>
     <span style="color:#00d">class</span> Traits <span style="color:#000080">=</span> <a href="char_traits.html" style="color:#003080"><span>std::<span>char_traits</span></span></a><span style="color:#000080">&lt;</span>CharT<span style="color:#000080">&gt;</span>, <br>
     <span style="color:#00d">class</span> Allocator <span style="color:#000080">=</span> <a href="../memory/allocator.html" style="color:#003080"><span>std::<span>allocator</span></span></a><span style="color:#000080">&lt;</span>CharT<span style="color:#000080">&gt;</span><br>
@@ -65,11 +65,11 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <span style="color:#000080">&gt;</span> <span style="color:#00d">class</span> basic_string<span style="color:#008080">;</span></span></div>
 </td>
 <td> (1) </td>
-<td style="padding-right: 0">  </td>
+<td style="padding-right:0">  </td>
 </tr>
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-size: 16pt;padding: 0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">namespace</span> pmr <span style="color:#008000">{</span><br>
+<td style="font-size: 16.0pt;padding:0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">namespace</span> pmr <span style="color:#008000">{</span><br>
 <p style="line-height:1.2em">    <span style="color:#00d">template</span> <span style="color:#000080">&lt;</span><span style="color:#00d">class</span> CharT, <span style="color:#00d">class</span> Traits <span style="color:#000080">=</span> <a href="char_traits.html" style="color:#003080"><span>std::<span>char_traits</span></span></a><span style="color:#000080">&lt;</span>CharT<span style="color:#000080">&gt;&gt;</span><br>
     <span style="color:#00d">using</span> basic_string <span style="color:#000080">=</span> std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span> CharT, Traits,<br>
                                             std<span style="color:#008080">::</span><span>polymorphic_allocator</span><span style="color:#000080">&lt;</span>CharT<span style="color:#000080">&gt;&gt;</span><br>
@@ -77,13 +77,13 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <span style="color:#008000">}</span></span></div>
 </td>
 <td> (2) </td>
-<td> <span style="color: #008000;font-size: 12.8pt">(since C++17)</span> </td>
+<td> <span style="color:#008000;font-size: 12.8pt">(since C++17)</span> </td>
 </tr>
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="padding: 0"></td>
-<td style="padding: 0"></td>
-<td style="padding: 0"></td>
+<td style="padding:0"></td>
+<td style="padding:0"></td>
+<td style="padding:0"></td>
 </tr>
 </tbody></table>
 <p style="line-height:1.2em">The class template <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code> stores and manipulates sequences of <a href="../language/types.html#Character_types" title="cpp/language/types"><tt style='font-family:"DejaVu Sans Mono", courier, monospace'><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00f">char</span></span></span></tt></a>-like objects, which are non-array objects of <a href="../concept/TrivialType.html" title="cpp/concept/TrivialType">trivial type</a>. The class is dependent neither on the character type nor on the nature of operations on that type. The definitions of the operations are supplied via the <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Traits</code> template parameter - a specialization of <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="char_traits.html" title="cpp/string/char traits">std::char_traits</a></span> or a compatible traits class. <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Traits::char_type</code> and <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>CharT</code> must name the same type; otherwise the behavior is undefined. 
@@ -94,97 +94,97 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <p style="line-height:1.2em; margin-top:0; margin-bottom:0">The elements of a <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code> are stored contiguously, that is, for a basic_string <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>s</code>, <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#000040">&amp;</span><span style="color:#000040">*</span><span style="color:#008000">(</span>s.<span>begin</span><span style="color:#008000">(</span><span style="color:#008000">)</span> <span style="color:#000040">+</span> n<span style="color:#008000">)</span> <span style="color:#000080">==</span> <span style="color:#000040">&amp;</span><span style="color:#000040">*</span>s.<span>begin</span><span style="color:#008000">(</span><span style="color:#008000">)</span> <span style="color:#000040">+</span> n</span></span> for any n in <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>[0, s.size())</code>, or, equivalently, a pointer to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>s[0]</code> can be passed to functions that expect a pointer to the first element of a <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>CharT[]</code> array.
 </p>
 </td>
-<td style="padding:0.3em 0.2em"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0.3em 0.2em"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table>
-<p style="line-height:1.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::basic_string</code> satisfies the requirements of <a href="../concept/AllocatorAwareContainer.html" title="cpp/concept/AllocatorAwareContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>AllocatorAwareContainer</code></a>, <a href="../concept/SequenceContainer.html" title="cpp/concept/SequenceContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>SequenceContainer</code></a> <span style="margin:0; padding:0; border:1px solid silver"><span style="margin:0; padding:0">and <a href="../concept/ContiguousContainer.html" title="cpp/concept/ContiguousContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>ContiguousContainer</code></a></span> <span style="margin:0; padding:0"><span style="color: #008000;font-size: 12.8pt">(since C++17)</span></span></span>
+<p style="line-height:1.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::basic_string</code> satisfies the requirements of <a href="../concept/AllocatorAwareContainer.html" title="cpp/concept/AllocatorAwareContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>AllocatorAwareContainer</code></a>, <a href="../concept/SequenceContainer.html" title="cpp/concept/SequenceContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>SequenceContainer</code></a> <span style="margin:0; padding:0; border:1px solid silver"><span style="margin:0; padding:0">and <a href="../concept/ContiguousContainer.html" title="cpp/concept/ContiguousContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>ContiguousContainer</code></a></span> <span style="margin:0; padding:0"><span style="color:#008000;font-size: 12.8pt">(since C++17)</span></span></span>
 </p>
 <p style="line-height:1.2em">Several typedefs for common character types are provided:
 </p>
 <table style="background-color:transparent; border-spacing:0; max-width:60em">
 
 <tr>
-<td colspan="2" style="font-size: 12.8pt;line-height: 1em;padding: 0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>&lt;string&gt;</code> </div>
+<td colspan="2" style="font-size: 12.8pt;line-height:1em;padding:0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>&lt;string&gt;</code> </div>
 </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Type
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Type
 </td>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Definition
-</td>
-</tr>
-
-
-<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
-<tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::string</strong></span>
-</td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char</span><span style="color:#000080">&gt;</span></span></span>
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Definition
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::wstring</strong></span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::string</strong></span>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">wchar_t</span><span style="color:#000080">&gt;</span></span></span>
-</td>
-</tr>
-
-
-<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
-<tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::u16string</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++11)</span>
-</td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char16_t</span><span style="color:#000080">&gt;</span></span></span>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char</span><span style="color:#000080">&gt;</span></span></span>
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::u32string</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++11)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::wstring</strong></span>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char32_t</span><span style="color:#000080">&gt;</span></span></span>
-</td>
-</tr>
-
-
-<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
-<tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::string</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++17)</span>
-</td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char</span><span style="color:#000080">&gt;</span></span></span>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">wchar_t</span><span style="color:#000080">&gt;</span></span></span>
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::wstring</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++17)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::u16string</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++11)</span>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">wchar_t</span><span style="color:#000080">&gt;</span></span></span>
-</td>
-</tr>
-
-
-<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
-<tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::u16string</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++17)</span>
-</td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char16_t</span><span style="color:#000080">&gt;</span></span></span>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char16_t</span><span style="color:#000080">&gt;</span></span></span>
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::u32string</strong></span> <span style="color: #008000;font-size: 12.8pt">(C++17)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::u32string</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++11)</span>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char32_t</span><span style="color:#000080">&gt;</span></span></span>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char32_t</span><span style="color:#000080">&gt;</span></span></span>
+</td>
+</tr>
+
+
+<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
+<tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::string</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++17)</span>
+</td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char</span><span style="color:#000080">&gt;</span></span></span>
+</td>
+</tr>
+
+
+<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
+<tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::wstring</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++17)</span>
+</td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">wchar_t</span><span style="color:#000080">&gt;</span></span></span>
+</td>
+</tr>
+
+
+<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
+<tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::u16string</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++17)</span>
+</td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char16_t</span><span style="color:#000080">&gt;</span></span></span>
+</td>
+</tr>
+
+
+<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
+<tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><strong style="font-weight:bold">std::pmr::u32string</strong></span> <span style="color:#008000;font-size: 12.8pt">(C++17)</span>
+</td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'>std<span style="color:#008080">::</span><span>pmr</span><span style="color:#008080">::</span><span>basic_string</span><span style="color:#000080">&lt;</span><span style="color:#00f">char32_t</span><span style="color:#000080">&gt;</span></span></span>
 </td>
 </tr>
 
@@ -223,160 +223,160 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Member type
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Member type
 </td>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Definition
-</td>
-</tr>
-
-
-<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
-<tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>traits_type</code>
-</td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Traits</code>
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Definition
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>traits_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>CharT</code>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Traits</code>
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>allocator_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>CharT</code>
+</td>
+</tr>
+
+
+<tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
+<tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>allocator_type</code>
+</td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>size_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>size_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::size_type</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>size_type</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>difference_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>difference_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::difference_type</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>difference_type</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reference</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reference</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::reference</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type&amp;</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reference</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reference</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::const_reference</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const value_type&amp;</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>pointer</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>pointer</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::pointer</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>pointer</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_pointer</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_pointer</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::const_pointer</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>const_pointer</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <a href="../concept/RandomAccessIterator.html" title="cpp/concept/RandomAccessIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>RandomAccessIterator</code></a> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <a href="../concept/RandomAccessIterator.html" title="cpp/concept/RandomAccessIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>RandomAccessIterator</code></a> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  Constant <a href="../concept/RandomAccessIterator.html" title="cpp/concept/RandomAccessIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>RandomAccessIterator</code></a> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  Constant <a href="../concept/RandomAccessIterator.html" title="cpp/concept/RandomAccessIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>RandomAccessIterator</code></a> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reverse_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reverse_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>iterator<span style="color:#000080">&gt;</span></span></span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>iterator<span style="color:#000080">&gt;</span></span></span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reverse_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reverse_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>const_iterator<span style="color:#000080">&gt;</span></span></span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>const_iterator<span style="color:#000080">&gt;</span></span></span> </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Member_functions">Member functions</span></h3>
@@ -384,39 +384,39 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="basic_string/basic_string.html" title="cpp/string/basic string/basic string"> <table><tr><td>(constructor)</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="basic_string/basic_string.html" title="cpp/string/basic string/basic string"> <table><tr><td>(constructor)</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  constructs a <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code> <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  constructs a <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code> <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><table><tr><td>(destructor)</td></tr></table></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><table><tr><td>(destructor)</td></tr></table></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  destroys the string, deallocating internal storage if used <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  destroys the string, deallocating internal storage if used <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span>
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%3D.html" title="cpp/string/basic string/operator="> <table><tr><td>operator=</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%3D.html" title="cpp/string/basic string/operator="> <table><tr><td>operator=</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   assigns values to the string  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   assigns values to the string  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/assign.html" title="cpp/string/basic string/assign"> <table><tr><td>assign</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/assign.html" title="cpp/string/basic string/assign"> <table><tr><td>assign</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">    assign characters to a string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">    assign characters to a string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/get_allocator.html" title="cpp/string/basic string/get allocator"> <table><tr><td>get_allocator</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/get_allocator.html" title="cpp/string/basic string/get allocator"> <table><tr><td>get_allocator</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the associated allocator  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the associated allocator  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -428,60 +428,60 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/at.html" title="cpp/string/basic string/at"> <table><tr><td>at</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/at.html" title="cpp/string/basic string/at"> <table><tr><td>at</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">    accesses the specified character with bounds checking <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">    accesses the specified character with bounds checking <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_at.html" title="cpp/string/basic string/operator at"> <table><tr><td>operator[]</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_at.html" title="cpp/string/basic string/operator at"> <table><tr><td>operator[]</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   accesses the specified character <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   accesses the specified character <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/front.html" title="cpp/string/basic string/front"> <table><tr><td>front</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   accesses the first character <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   accesses the first character <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/back.html" title="cpp/string/basic string/back"> <table><tr><td>back</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   accesses the last character <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   accesses the last character <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/data.html" title="cpp/string/basic string/data"> <table><tr><td>data</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/data.html" title="cpp/string/basic string/data"> <table><tr><td>data</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a pointer to the first character of a string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a pointer to the first character of a string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/c_str.html" title="cpp/string/basic string/c str"> <table><tr><td>c_str</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/c_str.html" title="cpp/string/basic string/c str"> <table><tr><td>c_str</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a non-modifiable standard C character array version of the string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a non-modifiable standard C character array version of the string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_basic_string_view.html" title="cpp/string/basic string/operator basic string view"> <table><tr><td>operator basic_string_view</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a non-modifiable string_view  into the entire string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a non-modifiable string_view  into the entire string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -493,66 +493,66 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/begin.html" title="cpp/string/basic string/begin"> <table>
 <tr><td>begin</td></tr>
 <tr><td>cbegin</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
 <tr><td></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the beginning  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the beginning  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/end.html" title="cpp/string/basic string/end"> <table>
 <tr><td>end </td></tr>
 <tr><td>cend</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
 <tr><td></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the end  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the end  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/rbegin.html" title="cpp/string/basic string/rbegin"> <table>
 <tr><td>rbegin</td></tr>
 <tr><td> crbegin</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
 <tr><td></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a reverse iterator to the beginning  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a reverse iterator to the beginning  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/rend.html" title="cpp/string/basic string/rend"> <table>
 <tr><td>rend</td></tr>
 <tr><td> crend</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
 <tr><td></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a reverse iterator to the end  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a reverse iterator to the end  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -564,50 +564,50 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/empty.html" title="cpp/string/basic string/empty"> <table><tr><td>empty</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/empty.html" title="cpp/string/basic string/empty"> <table><tr><td>empty</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   checks whether the string is empty  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   checks whether the string is empty  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/size.html" title="cpp/string/basic string/size"> <table>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/size.html" title="cpp/string/basic string/size"> <table>
 <tr><td>size</td></tr>
 <tr><td>length</td></tr>
 </table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the number of characters  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the number of characters  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/max_size.html" title="cpp/string/basic string/max size"> <table><tr><td>max_size</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/max_size.html" title="cpp/string/basic string/max size"> <table><tr><td>max_size</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the maximum number of characters  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the maximum number of characters  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/reserve.html" title="cpp/string/basic string/reserve"> <table><tr><td>reserve</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/reserve.html" title="cpp/string/basic string/reserve"> <table><tr><td>reserve</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   reserves storage  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   reserves storage  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/capacity.html" title="cpp/string/basic string/capacity"> <table><tr><td>capacity</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/capacity.html" title="cpp/string/basic string/capacity"> <table><tr><td>capacity</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the number of characters that can be held in currently allocated storage  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the number of characters that can be held in currently allocated storage  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/shrink_to_fit.html" title="cpp/string/basic string/shrink to fit"> <table><tr><td>shrink_to_fit</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   reduces memory usage by freeing unused memory  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   reduces memory usage by freeing unused memory  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -619,116 +619,116 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/clear.html" title="cpp/string/basic string/clear"> <table><tr><td>clear</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/clear.html" title="cpp/string/basic string/clear"> <table><tr><td>clear</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   clears the contents <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   clears the contents <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/insert.html" title="cpp/string/basic string/insert"> <table><tr><td>insert</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/insert.html" title="cpp/string/basic string/insert"> <table><tr><td>insert</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   inserts characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   inserts characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/erase.html" title="cpp/string/basic string/erase"> <table><tr><td>erase</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/erase.html" title="cpp/string/basic string/erase"> <table><tr><td>erase</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   removes characters  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   removes characters  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/push_back.html" title="cpp/string/basic string/push back"> <table><tr><td>push_back</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/push_back.html" title="cpp/string/basic string/push back"> <table><tr><td>push_back</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   appends a character to the end <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   appends a character to the end <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/pop_back.html" title="cpp/string/basic string/pop back"> <table><tr><td>pop_back</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   removes the last character  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   removes the last character  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/append.html" title="cpp/string/basic string/append"> <table><tr><td>append</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/append.html" title="cpp/string/basic string/append"> <table><tr><td>append</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   appends characters to the end <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   appends characters to the end <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%2B%3D.html" title="cpp/string/basic string/operator+="> <table><tr><td>operator+=</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%2B%3D.html" title="cpp/string/basic string/operator+="> <table><tr><td>operator+=</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   appends characters to the end <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   appends characters to the end <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/compare.html" title="cpp/string/basic string/compare"> <table><tr><td>compare</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/compare.html" title="cpp/string/basic string/compare"> <table><tr><td>compare</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   compares two strings <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   compares two strings <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/starts_with.html" title="cpp/string/basic string/starts with"> <table><tr><td>starts_with</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   checks if the string starts with the given prefix  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   checks if the string starts with the given prefix  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/ends_with.html" title="cpp/string/basic string/ends with"> <table><tr><td>ends_with</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   checks if the string ends with the given suffix  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   checks if the string ends with the given suffix  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/replace.html" title="cpp/string/basic string/replace"> <table><tr><td>replace</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/replace.html" title="cpp/string/basic string/replace"> <table><tr><td>replace</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   replaces specified portion of a string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   replaces specified portion of a string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/substr.html" title="cpp/string/basic string/substr"> <table><tr><td>substr</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/substr.html" title="cpp/string/basic string/substr"> <table><tr><td>substr</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a substring <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a substring <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/copy.html" title="cpp/string/basic string/copy"> <table><tr><td>copy</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/copy.html" title="cpp/string/basic string/copy"> <table><tr><td>copy</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   copies characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   copies characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/resize.html" title="cpp/string/basic string/resize"> <table><tr><td>resize</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/resize.html" title="cpp/string/basic string/resize"> <table><tr><td>resize</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   changes the number of characters stored  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   changes the number of characters stored  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/swap.html" title="cpp/string/basic string/swap"> <table><tr><td>swap</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/swap.html" title="cpp/string/basic string/swap"> <table><tr><td>swap</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   swaps the contents  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   swaps the contents  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -740,44 +740,44 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find.html" title="cpp/string/basic string/find"> <table><tr><td>find</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find.html" title="cpp/string/basic string/find"> <table><tr><td>find</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find characters in the string <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find characters in the string <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/rfind.html" title="cpp/string/basic string/rfind"> <table><tr><td>rfind</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/rfind.html" title="cpp/string/basic string/rfind"> <table><tr><td>rfind</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find the last occurrence of a substring <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find the last occurrence of a substring <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_first_of.html" title="cpp/string/basic string/find first of"> <table><tr><td>find_first_of</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_first_of.html" title="cpp/string/basic string/find first of"> <table><tr><td>find_first_of</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find first occurrence of characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find first occurrence of characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_first_not_of.html" title="cpp/string/basic string/find first not of"> <table><tr><td>find_first_not_of</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_first_not_of.html" title="cpp/string/basic string/find first not of"> <table><tr><td>find_first_not_of</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find first absence of characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find first absence of characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_last_of.html" title="cpp/string/basic string/find last of"> <table><tr><td>find_last_of</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_last_of.html" title="cpp/string/basic string/find last of"> <table><tr><td>find_last_of</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find last occurrence of characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find last occurrence of characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_last_not_of.html" title="cpp/string/basic string/find last not of"> <table><tr><td>find_last_not_of</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/find_last_not_of.html" title="cpp/string/basic string/find last not of"> <table><tr><td>find_last_not_of</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   find last absence of characters <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   find last absence of characters <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -789,12 +789,12 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/npos.html" title="cpp/string/basic string/npos"> <table><tr><td>npos</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #808080;font-size: 12.8pt">[static]</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#808080;font-size: 12.8pt">[static]</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   special value. The exact meaning depends on the context <br> <span style="color: #008000;font-size: 12.8pt">(public static member constant)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   special value. The exact meaning depends on the context <br> <span style="color:#008000;font-size: 12.8pt">(public static member constant)</span> </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Non-member_functions">Non-member functions</span></h3>
@@ -802,14 +802,14 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%2B.html" title="cpp/string/basic string/operator+"> <table><tr><td>operator+</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator%2B.html" title="cpp/string/basic string/operator+"> <table><tr><td>operator+</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   concatenates two strings or a string and a char  <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   concatenates two strings or a string and a char  <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_cmp.html" title="cpp/string/basic string/operator cmp"> <table>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_cmp.html" title="cpp/string/basic string/operator cmp"> <table>
 <tr><td>operator==</td></tr>
 <tr><td>operator!=</td></tr>
 <tr><td>operator&lt;</td></tr>
@@ -818,15 +818,15 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <tr><td>operator&gt;=</td></tr>
 </table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   lexicographically compares two strings  <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   lexicographically compares two strings  <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/swap2.html" title="cpp/string/basic string/swap2"> <table><tr><td>std::swap<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">(std::basic_string)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/swap2.html" title="cpp/string/basic string/swap2"> <table><tr><td>std::swap<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">(std::basic_string)</span>
 </td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   specializes the <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../algorithm/swap.html" title="cpp/algorithm/swap">std::swap</a></span> algorithm <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   specializes the <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../algorithm/swap.html" title="cpp/algorithm/swap">std::swap</a></span> algorithm <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 
@@ -838,19 +838,19 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_ltltgtgt.html" title="cpp/string/basic string/operator ltltgtgt"> <table>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_ltltgtgt.html" title="cpp/string/basic string/operator ltltgtgt"> <table>
 <tr><td>operator&lt;&lt;</td></tr>
 <tr><td>operator&gt;&gt;</td></tr>
 </table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   performs stream input and output on strings  <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   performs stream input and output on strings  <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/getline.html" title="cpp/string/basic string/getline"> <table><tr><td>getline</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/getline.html" title="cpp/string/basic string/getline"> <table><tr><td>getline</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   read data from an I/O stream into a string <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   read data from an I/O stream into a string <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 
@@ -862,92 +862,92 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/stol.html" title="cpp/string/basic string/stol"> <table>
 <tr><td>stoi</td></tr>
 <tr><td>stol</td></tr>
 <tr><td>stoll</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   converts a string to a signed integer  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   converts a string to a signed integer  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/stoul.html" title="cpp/string/basic string/stoul"> <table>
 <tr><td>stoul</td></tr>
 <tr><td>stoull</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   converts a string to an unsigned integer  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   converts a string to an unsigned integer  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/stof.html" title="cpp/string/basic string/stof"> <table>
 <tr><td>stof</td></tr>
 <tr><td>stod</td></tr>
 <tr><td>stold</td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   converts a string to a floating point value  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   converts a string to a floating point value  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/to_string.html" title="cpp/string/basic string/to string"> <table><tr><td>to_string</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   converts an integral or floating point value to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>string</code>  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   converts an integral or floating point value to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>string</code>  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/to_wstring.html" title="cpp/string/basic string/to wstring"> <table><tr><td>to_wstring</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   converts an integral or floating point value to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>wstring</code>  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   converts an integral or floating point value to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>wstring</code>  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Literals">Literals</span></h3>
 <table style="background-color:transparent; border-spacing:0; max-width:60em">
 
 <tr>
-<td colspan="2" style="font-size: 12.8pt;line-height: 1em;padding: 0"> <div>Defined in inline namespace <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::literals::string_literals</code> </div>
+<td colspan="2" style="font-size: 12.8pt;line-height:1em;padding:0"> <div>Defined in inline namespace <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::literals::string_literals</code> </div>
 </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/operator_q__q_s.html" title='cpp/string/basic string/operator""s'> <table><tr><td>operator""s</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++14)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++14)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   Converts a character array literal to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code>  <br> <span style="color: #008000;font-size: 12.8pt">(function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   Converts a character array literal to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>basic_string</code>  <br> <span style="color:#008000;font-size: 12.8pt">(function)</span> </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Helper_classes">Helper classes</span></h3>
@@ -955,41 +955,41 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="basic_string/hash.html" title="cpp/string/basic string/hash"> <table>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::u16string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::u16string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::u32string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::u32string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::wstring&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::wstring&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::pmr::string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::pmr::string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::pmr::u16string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::pmr::u16string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::pmr::u32string&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::pmr::u32string&gt;</span>
 </td></tr>
-<tr><td>std::hash<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">&lt;std::pmr::wstring&gt;</span>
+<tr><td>std::hash<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">&lt;std::pmr::wstring&gt;</span>
 </td></tr>
 </table></a></div></td>
 <td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr>
-<tr><td><span style="color: #008000;font-size: 12.8pt">(C++20)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr>
+<tr><td><span style="color:#008000;font-size: 12.8pt">(C++20)</span></td></tr>
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   hash support for strings  <br> <span style="color: #008000;font-size: 12.8pt">(class template specialization)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   hash support for strings  <br> <span style="color:#008000;font-size: 12.8pt">(class template specialization)</span> </td>
 </tr>
 </table>
-<h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Deduction_guides.28since_C.2B.2B17.29"><a href="basic_string/deduction_guides.html" title="cpp/string/basic string/deduction guides">Deduction guides</a><span style="color: #008000;font-size: 12.8pt">(since C++17)</span></span></h3>
+<h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Deduction_guides.28since_C.2B.2B17.29"><a href="basic_string/deduction_guides.html" title="cpp/string/basic string/deduction guides">Deduction guides</a><span style="color:#008000;font-size: 12.8pt">(since C++17)</span></span></h3>
 
 <!-- 
 NewPP limit report

--- a/tests/preprocess_cssless_data/multiset_expected.html
+++ b/tests/preprocess_cssless_data/multiset_expected.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" style='font-family: "DejaVu Sans", arial, sans-serif;font-size: 16pt'>
+<html lang="en" dir="ltr" style='font-family:"DejaVu Sans", arial, sans-serif;font-size: 16.0pt'>
 <head>
 <title>std::multiset - cppreference.com</title>
 <meta charset="UTF-8">
@@ -19,7 +19,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 }</script>
 <!--[if lt IE 7]><style type="text/css">body{behavior:url("/mwiki/skins/cppreference2/csshover.min.htc")}</style><![endif]-->
 </head>
-<body style='font-family: "DejaVu Sans", arial, sans-serif;font-size: 16pt;background-color: white' bgcolor="white">
+<body style='font-family:"DejaVu Sans", arial, sans-serif;font-size: 16.0pt;background-color:white' bgcolor="white">
         <!-- header -->
         <!-- /header -->
         <!-- content -->
@@ -27,8 +27,8 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
             <div id="content" style="line-height:1.2em; position:static; margin:0; width:48.75em; padding-top:32px" width="48.75em">
                 <a id="top"></a>
                 <!-- firstHeading -->
-                <h1 id="firstHeading" style="font-size: 32pt">
-<span style="font-size: 22.4pt;line-height: 130%">std::</span>multiset</h1>
+                <h1 id="firstHeading" style="font-size: 32.0pt">
+<span style="font-size: 22.4pt;line-height:130%">std::</span>multiset</h1>
                 <!-- /firstHeading -->
                 <!-- bodyContent -->
                 <div id="bodyContent" style="line-height:1.2em; position:static">
@@ -39,25 +39,25 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
                                                             <!-- bodycontent -->
                     <div id="mw-content-text" lang="en" dir="ltr">
 <div style="display:inline-block; height:1.72em; left:0; position:absolute; top:0" height="1.72em">
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-inv-tab.png);background-position: left bottom;background-repeat: no-repeat;width: 8px;border-bottom-width: 0" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><a href="../../cpp.html" title="cpp"> C++</a></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><a href="../container.html" title="cpp/container"> Containers library</a></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px" height="100%" width="8"> </div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;padding-left: 0.2em;padding-right: 0.2em" height="100%"><strong style="font-weight:bold"><tt style='font-family:"DejaVu Sans Mono", courier, monospace'>std::multiset</tt></strong></div>
-<div style="-moz-box-sizing: border-box;background-origin: border-box;border-bottom: 1px solid silver;box-sizing: border-box;float: left;font-size: 14.4pt;height: 100%;padding-bottom: 0.3em;padding-top: 0.4em;background-image: url(skins/cppreference2/images/navbar-tab.png);background-position: right bottom;background-repeat: no-repeat;width: 8px;border-bottom-width: 0" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-inv-tab.png);background-position:left bottom;background-repeat:no-repeat;width:8px;border-bottom-width:0" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><a href="../../cpp.html" title="cpp"> C++</a></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><a href="../container.html" title="cpp/container"> Containers library</a></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px" height="100%" width="8"> </div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;padding-left:0.2em;padding-right:0.2em" height="100%"><strong style="font-weight:bold"><tt style='font-family:"DejaVu Sans Mono", courier, monospace'>std::multiset</tt></strong></div>
+<div style="-moz-box-sizing:border-box;background-origin:border-box;border-bottom:1px solid silver;box-sizing:border-box;float:left;font-size: 14.4pt;height:100%;padding-bottom:0.3em;padding-top:0.4em;background-image:url(skins/cppreference2/images/navbar-tab.png);background-position:right bottom;background-repeat:no-repeat;width:8px;border-bottom-width:0" height="100%" width="8"> </div>
 </div>
 <table style="background-color:transparent; border-spacing:0; display:block; padding:0.5em 0"><tbody>
 <tr>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../header/set.html" title="cpp/header/set">&lt;set&gt;</a></code>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"> <div>Defined in header <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../header/set.html" title="cpp/header/set">&lt;set&gt;</a></code>
  </div>
 </td>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"></td>
-<td style="font-size: 12.8pt;line-height: 1em;padding: 0"></td>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"></td>
+<td style="font-size: 12.8pt;line-height:1em;padding:0"></td>
 </tr>
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-size: 16pt;padding: 0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">template</span><span style="color:#000080">&lt;</span><br>
+<td style="font-size: 16.0pt;padding:0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">template</span><span style="color:#000080">&lt;</span><br>
 <p style="line-height:1.2em">    <span style="color:#00d">class</span> Key,<br>
     <span style="color:#00d">class</span> Compare <span style="color:#000080">=</span> <a href="../utility/functional/less.html" style="color:#003080"><span>std::<span>less</span></span></a><span style="color:#000080">&lt;</span>Key<span style="color:#000080">&gt;</span>,<br>
     <span style="color:#00d">class</span> Allocator <span style="color:#000080">=</span> <a href="../memory/allocator.html" style="color:#003080"><span>std::<span>allocator</span></span></a><span style="color:#000080">&lt;</span>Key<span style="color:#000080">&gt;</span><br>
@@ -65,11 +65,11 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <span style="color:#000080">&gt;</span> <span style="color:#00d">class</span> multiset<span style="color:#008080">;</span></span></div>
 </td>
 <td> (1) </td>
-<td style="padding-right: 0">  </td>
+<td style="padding-right:0">  </td>
 </tr> 
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-size: 16pt;padding: 0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">namespace</span> pmr <span style="color:#008000">{</span><br>
+<td style="font-size: 16.0pt;padding:0.3em 2em 0.2em 1em"> <div><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><span style="color:#00d">namespace</span> pmr <span style="color:#008000">{</span><br>
 <p style="line-height:1.2em">    <span style="color:#00d">template</span> <span style="color:#000080">&lt;</span><span style="color:#00d">class</span> Key, <span style="color:#00d">class</span> Compare <span style="color:#000080">=</span> <a href="../utility/functional/less.html" style="color:#003080"><span>std::<span>less</span></span></a><span style="color:#000080">&lt;</span>Key<span style="color:#000080">&gt;&gt;</span><br>
     <span style="color:#00d">using</span> multiset <span style="color:#000080">=</span> std<span style="color:#008080">::</span><span>multiset</span><span style="color:#000080">&lt;</span>Key, Compare,<br>
                                    <a href="../memory/polymorphic_allocator.html" style="color:#003080"><span>std::<span>pmr</span><span style="color:#008080">::</span><span>polymorphic_allocator</span></span></a><span style="color:#000080">&lt;</span>Key<span style="color:#000080">&gt;&gt;</span><span style="color:#008080">;</span><br>
@@ -77,20 +77,20 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <span style="color:#008000">}</span></span></div>
 </td>
 <td> (2) </td>
-<td> <span style="color: #008000;font-size: 12.8pt">(since C++17)</span> </td>
+<td> <span style="color:#008000;font-size: 12.8pt">(since C++17)</span> </td>
 </tr>
 <tr><td colspan="3" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="padding: 0"></td>
-<td style="padding: 0"></td>
-<td style="padding: 0"></td>
+<td style="padding:0"></td>
+<td style="padding:0"></td>
+<td style="padding:0"></td>
 </tr>
 </tbody></table>
 <p style="line-height:1.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::multiset</code> is an associative container that contains a sorted set of objects of type Key. Unlike set, multiple keys with equivalent values are allowed. Sorting is done using the key comparison function Compare. Search, insertion, and removal operations have logarithmic complexity.
 </p>
 <p style="line-height:1.2em">Everywhere the standard library uses the <a href="../concept/Compare.html" title="cpp/concept/Compare"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code></a> concept, equivalence is determined by using the equivalence relation as described on <a href="../concept/Compare.html" title="cpp/concept/Compare"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code></a>.  In imprecise terms, two objects <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>a</code> and <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>b</code> are considered equivalent if neither compares less than the other: <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>!comp(a, b) &amp;&amp; !comp(b, a)</code>.
 </p>
-<p style="line-height:1.2em">The order of the elements that compare equivalent is the order of insertion and does not change. <span style="color: #008000;font-size: 12.8pt">(since C++11)</span>
+<p style="line-height:1.2em">The order of the elements that compare equivalent is the order of insertion and does not change. <span style="color:#008000;font-size: 12.8pt">(since C++11)</span>
 </p>
 <p style="line-height:1.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>std::multiset</code> meets the requirements of <a href="../concept/Container.html" title="cpp/concept/Container"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Container</code></a>, <a href="../concept/AllocatorAwareContainer.html" title="cpp/concept/AllocatorAwareContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>AllocatorAwareContainer</code></a>, <a href="../concept/AssociativeContainer.html" title="cpp/concept/AssociativeContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>AssociativeContainer</code></a> and <a href="../concept/ReversibleContainer.html" title="cpp/concept/ReversibleContainer"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>ReversibleContainer</code></a>.
 </p>
@@ -99,169 +99,169 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Member type
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Member type
 </td>
-<td style="font-weight: bold;line-height: 1.1em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap">  Definition
+<td style="font-weight:bold;line-height:1.1em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap">  Definition
 </td>
 </tr>
 
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>key_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>key_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Key</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Key</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Key</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Key</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>size_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>size_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  Unsigned integer type (usually <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../types/size_t.html" title="cpp/types/size t">std::size_t</a></span>) </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  Unsigned integer type (usually <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../types/size_t.html" title="cpp/types/size t">std::size_t</a></span>) </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>difference_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>difference_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  Signed integer type (usually <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../types/ptrdiff_t.html" title="cpp/types/ptrdiff t">std::ptrdiff_t</a></span>) </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  Signed integer type (usually <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../types/ptrdiff_t.html" title="cpp/types/ptrdiff t">std::ptrdiff_t</a></span>) </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>key_compare</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>key_compare</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_compare</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_compare</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Compare</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>allocator_type</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>allocator_type</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator</code> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator</code> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reference</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reference</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::reference</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>value_type&amp;</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reference</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reference</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::const_reference</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const value_type&amp;</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>pointer</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>pointer</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::pointer</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>pointer</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_pointer</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_pointer</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>Allocator::const_pointer</code></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../memory/allocator_traits.html" style="color:#003080"><span>std::<span>allocator_traits</span></span></a><span style="color:#000080">&lt;</span>Allocator<span style="color:#000080">&gt;</span><span style="color:#008080">::</span><span>const_pointer</span></span></span></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   <table style="background-color:transparent; border-collapse:collapse; border-spacing:0; display:inline-table">
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em"><a href="../concept/BidirectionalIterator.html" title="cpp/concept/BidirectionalIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>BidirectionalIterator</code></a></td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(until C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(until C++11)</span></td>
 </tr>
 <tr>
 <td style="padding:0; border:none; border-right:none; padding-right:0.2em">Constant <a href="../concept/BidirectionalIterator.html" title="cpp/concept/BidirectionalIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>BidirectionalIterator</code></a>
 </td>
-<td style="padding:0; border:none"><span style="color: #008000;font-size: 12.8pt">(since C++11)</span></td>
+<td style="padding:0; border:none"><span style="color:#008000;font-size: 12.8pt">(since C++11)</span></td>
 </tr>
 </table> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  Constant <a href="../concept/BidirectionalIterator.html" title="cpp/concept/BidirectionalIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>BidirectionalIterator</code></a> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  Constant <a href="../concept/BidirectionalIterator.html" title="cpp/concept/BidirectionalIterator"><code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>BidirectionalIterator</code></a> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reverse_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>reverse_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>iterator<span style="color:#000080">&gt;</span></span></span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>iterator<span style="color:#000080">&gt;</span></span></span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reverse_iterator</code>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_reverse_iterator</code>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>const_iterator<span style="color:#000080">&gt;</span></span></span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  <span style="background-color:rgba(0, 0, 0, 0.031); border:1px solid #D6D6D6; border-radius:3px; display:inline-block; margin:0 2px; padding:0 2px" bgcolor="rgba(0, 0, 0, 0.031)"><span style='line-height:normal; white-space:nowrap; font-family:"DejaVu Sans Mono", courier, monospace'><a href="../iterator/reverse_iterator.html" style="color:#003080"><span>std::<span>reverse_iterator</span></span></a><span style="color:#000080">&lt;</span>const_iterator<span style="color:#000080">&gt;</span></span></span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>node_type</code><span style="color: #008000;font-size: 12.8pt">(since C++17)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>node_type</code><span style="color:#008000;font-size: 12.8pt">(since C++17)</span>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  a specialization of <a href="node_handle.html" title="cpp/container/node handle">node handle</a> representing a container node </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  a specialization of <a href="node_handle.html" title="cpp/container/node handle">node handle</a> representing a container node </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Member_functions">Member functions</span></h3>
@@ -269,30 +269,30 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="multiset/multiset.html" title="cpp/container/multiset/multiset"> <table><tr><td>(constructor)</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="multiset/multiset.html" title="cpp/container/multiset/multiset"> <table><tr><td>(constructor)</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  constructs the <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>multiset</code> <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  constructs the <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>multiset</code> <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="multiset/%7Emultiset.html" title="cpp/container/multiset/~multiset"> <table><tr><td>(destructor)</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSans, "DejaVu Sans", arial, sans-serif; font-weight:normal' valign="middle"><a href="multiset/%7Emultiset.html" title="cpp/container/multiset/~multiset"> <table><tr><td>(destructor)</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">  destructs the <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>multiset</code> <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">  destructs the <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>multiset</code> <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/operator%3D.html" title="cpp/container/multiset/operator="> <table><tr><td>operator=</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/operator%3D.html" title="cpp/container/multiset/operator="> <table><tr><td>operator=</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   assigns values to the container  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   assigns values to the container  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/get_allocator.html" title="cpp/container/multiset/get allocator"> <table><tr><td>get_allocator</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/get_allocator.html" title="cpp/container/multiset/get allocator"> <table><tr><td>get_allocator</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the associated allocator  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the associated allocator  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -304,7 +304,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/begin.html" title="cpp/container/multiset/begin"> <table>
 <tr><td>begin</td></tr>
 <tr><td> cbegin</td></tr>
@@ -315,12 +315,12 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the beginning  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the beginning  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/end.html" title="cpp/container/multiset/end"> <table>
 <tr><td>end </td></tr>
 <tr><td>cend</td></tr>
@@ -331,12 +331,12 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the end  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the end  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/rbegin.html" title="cpp/container/multiset/rbegin"> <table>
 <tr><td>rbegin</td></tr>
 <tr><td> crbegin</td></tr>
@@ -347,12 +347,12 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a reverse iterator to the beginning  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a reverse iterator to the beginning  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/rend.html" title="cpp/container/multiset/rend"> <table>
 <tr><td>rend</td></tr>
 <tr><td> crend</td></tr>
@@ -363,7 +363,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 </table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns a reverse iterator to the end  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns a reverse iterator to the end  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -375,23 +375,23 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/empty.html" title="cpp/container/multiset/empty"> <table><tr><td>empty</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/empty.html" title="cpp/container/multiset/empty"> <table><tr><td>empty</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   checks whether the container is empty  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   checks whether the container is empty  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/size.html" title="cpp/container/multiset/size"> <table><tr><td>size</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/size.html" title="cpp/container/multiset/size"> <table><tr><td>size</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the number of elements  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the number of elements  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/max_size.html" title="cpp/container/multiset/max size"> <table><tr><td>max_size</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/max_size.html" title="cpp/container/multiset/max size"> <table><tr><td>max_size</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the maximum possible number of elements  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the maximum possible number of elements  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -403,70 +403,70 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/clear.html" title="cpp/container/multiset/clear"> <table><tr><td>clear</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/clear.html" title="cpp/container/multiset/clear"> <table><tr><td>clear</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   clears the contents  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   clears the contents  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/insert.html" title="cpp/container/multiset/insert"> <table><tr><td>insert</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/insert.html" title="cpp/container/multiset/insert"> <table><tr><td>insert</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   inserts elements <span style="margin:0; padding:0; border:1px solid silver"><span style="margin:0; padding:0">or nodes</span> <span style="margin:0; padding:0"><span style="color: #008000;font-size: 12.8pt">(since C++17)</span></span></span> <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   inserts elements <span style="margin:0; padding:0; border:1px solid silver"><span style="margin:0; padding:0">or nodes</span> <span style="margin:0; padding:0"><span style="color:#008000;font-size: 12.8pt">(since C++17)</span></span></span> <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/emplace.html" title="cpp/container/multiset/emplace"> <table><tr><td>emplace</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   constructs element in-place  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   constructs element in-place  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/emplace_hint.html" title="cpp/container/multiset/emplace hint"> <table><tr><td>emplace_hint</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++11)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   constructs elements in-place using a hint  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   constructs elements in-place using a hint  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/erase.html" title="cpp/container/multiset/erase"> <table><tr><td>erase</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/erase.html" title="cpp/container/multiset/erase"> <table><tr><td>erase</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   erases elements  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   erases elements  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/swap.html" title="cpp/container/multiset/swap"> <table><tr><td>swap</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/swap.html" title="cpp/container/multiset/swap"> <table><tr><td>swap</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   swaps the contents  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   swaps the contents  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/extract.html" title="cpp/container/multiset/extract"> <table><tr><td>extract</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   extracts nodes from the container  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   extracts nodes from the container  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><table style="padding:0; margin:0; border:none;"><tr>
 <td><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/merge.html" title="cpp/container/multiset/merge"> <table><tr><td>merge</td></tr></table></a></div></td>
-<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color: #008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
+<td><div style="display:inline-table; padding:0; vertical-align:middle" valign="middle"><table><tr><td><span style="color:#008000;font-size: 12.8pt">(C++17)</span></td></tr></table></div></td>
 </tr></table></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   splices nodes from another container <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   splices nodes from another container <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -478,37 +478,37 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/count.html" title="cpp/container/multiset/count"> <table><tr><td>count</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/count.html" title="cpp/container/multiset/count"> <table><tr><td>count</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the number of elements matching specific key  <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the number of elements matching specific key  <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/find.html" title="cpp/container/multiset/find"> <table><tr><td>find</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/find.html" title="cpp/container/multiset/find"> <table><tr><td>find</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   finds element with specific key <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   finds element with specific key <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/equal_range.html" title="cpp/container/multiset/equal range"> <table><tr><td>equal_range</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/equal_range.html" title="cpp/container/multiset/equal range"> <table><tr><td>equal_range</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns range of elements matching a specific key <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns range of elements matching a specific key <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/lower_bound.html" title="cpp/container/multiset/lower bound"> <table><tr><td>lower_bound</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/lower_bound.html" title="cpp/container/multiset/lower bound"> <table><tr><td>lower_bound</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the first element <i>not less</i> than the given key <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the first element <i>not less</i> than the given key <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/upper_bound.html" title="cpp/container/multiset/upper bound"> <table><tr><td>upper_bound</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/upper_bound.html" title="cpp/container/multiset/upper bound"> <table><tr><td>upper_bound</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns an iterator to the first element <i>greater</i> than the given key <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns an iterator to the first element <i>greater</i> than the given key <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 
@@ -520,16 +520,16 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/key_comp.html" title="cpp/container/multiset/key comp"> <table><tr><td>key_comp</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/key_comp.html" title="cpp/container/multiset/key comp"> <table><tr><td>key_comp</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the function that compares keys <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the function that compares keys <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/value_comp.html" title="cpp/container/multiset/value comp"> <table><tr><td>value_comp</td></tr></table></a></div></div>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/value_comp.html" title="cpp/container/multiset/value comp"> <table><tr><td>value_comp</td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   returns the function that compares keys in objects of type value_type <br> <span style="color: #008000;font-size: 12.8pt">(public member function)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   returns the function that compares keys in objects of type value_type <br> <span style="color:#008000;font-size: 12.8pt">(public member function)</span> </td>
 </tr>
 </table>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Non-member_functions">Non-member functions</span></h3>
@@ -537,7 +537,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/operator_cmp.html" title="cpp/container/multiset/operator cmp"> <table>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/operator_cmp.html" title="cpp/container/multiset/operator cmp"> <table>
 <tr><td>operator==</td></tr>
 <tr><td>operator!=</td></tr>
 <tr><td>operator&lt;</td></tr>
@@ -546,18 +546,18 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <tr><td>operator&gt;=</td></tr>
 </table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   lexicographically compares the values in the multiset  <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   lexicographically compares the values in the multiset  <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 
 <tr><td colspan="2" style="height:1px; font-size:1px; background-color: #ccc;"></td></tr>
 <tr>
-<td style="line-height: 1.2em;padding: 0.2em 0 0.25em 0.75em;white-space: nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/swap2.html" title="cpp/container/multiset/swap2"> <table><tr><td>std::swap<span style="font-size: 11.2pt;font-weight: normal;line-height: 130%">(std::multiset)</span>
+<td style="line-height:1.2em;padding:0.2em 0 0.25em 0.75em;white-space:nowrap" width="1px">  <div><div style='display:inline-table; padding:0; vertical-align:middle; font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace; font-weight:bold' valign="middle"><a href="multiset/swap2.html" title="cpp/container/multiset/swap2"> <table><tr><td>std::swap<span style="font-size: 11.2pt;font-weight:normal;line-height:130%">(std::multiset)</span>
 </td></tr></table></a></div></div>
 </td>
-<td style="line-height: 1.1em;padding-left: 0.75em;white-space: normal">   specializes the <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../algorithm/swap.html" title="cpp/algorithm/swap">std::swap</a></span> algorithm  <br> <span style="color: #008000;font-size: 12.8pt">(function template)</span> </td>
+<td style="line-height:1.1em;padding-left:0.75em;white-space:normal">   specializes the <span style='font-family:DejaVuSansMono, "DejaVu Sans Mono", courier, monospace'><a href="../algorithm/swap.html" title="cpp/algorithm/swap">std::swap</a></span> algorithm  <br> <span style="color:#008000;font-size: 12.8pt">(function template)</span> </td>
 </tr>
 </table>
-<h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Deduction_guides.28since_C.2B.2B17.29"><a href="multiset/deduction_guides.html" title="cpp/container/multiset/deduction guides">Deduction guides</a><span style="color: #008000;font-size: 12.8pt">(since C++17)</span></span></h3>
+<h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Deduction_guides.28since_C.2B.2B17.29"><a href="multiset/deduction_guides.html" title="cpp/container/multiset/deduction guides">Deduction guides</a><span style="color:#008000;font-size: 12.8pt">(since C++17)</span></span></h3>
 <h3 style="padding:1.1em 0 0.2em 0.75em"><span id="Notes">Notes</span></h3>
 <p style="line-height:1.2em">The member types <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code> and <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code> may be aliases to the same type. Since <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>iterator</code> is convertible to <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code>, <code style='background-color:transparent; font-family:"DejaVu Sans Mono", courier, monospace'>const_iterator</code> should be used in function parameter lists to avoid violations of the One Definition Rule.
 </p>

--- a/tests/test_preprocess_cssless.py
+++ b/tests/test_preprocess_cssless.py
@@ -101,10 +101,10 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr>
-        <td style="border: solid 1px green;padding: 1.5px">1</td>
-        <td style="border: none;padding: 1.5px">2</td>
+        <td style="border:solid 1px green;padding:1.5px">1</td>
+        <td style="border:none;padding:1.5px">2</td>
       </tr>
     </table>
   </one_more_block>
@@ -127,7 +127,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr><td>little text</td></tr>
     </table>
   </one_more_block>
@@ -152,7 +152,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr><td>
         <span>blabla</span>
         <span>blabla2</span>
@@ -179,7 +179,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr><td>
         <span style="color:#008000; font-size:0.8em">(C++11)</span>
       </td></tr>
@@ -208,7 +208,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr><td>
         <span>
           <div>bla</div>
@@ -237,7 +237,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <span>
         <span style="display:table-cell;">2</span>
       </span>
@@ -264,7 +264,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr>
         <span>1</span>
         <td>2</td>
@@ -293,7 +293,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <tr>
         <span style="display:table-row;">
           blabla
@@ -323,7 +323,7 @@ class TestConvertSpanTablesToTrTd(HTMLTestBase):
         expected = '''\
 <div>
   <one_more_block>
-    <table style="border: solid 1.5px red;padding: 2px">
+    <table style="border:solid 1.5px red;padding:2px">
       <span style="display:table-cell;">
         <span style="display:table-cell;">
           blabla
@@ -386,7 +386,7 @@ class TestConvertZeroTdWidthToNonzero(HTMLTestBase):
 
         expected = '''\
 <tr>
-  <td style="white-space: nowrap;border-top: 1px solid #CCC" width="1px">
+  <td style="white-space:nowrap;border-top:1px solid #CCC" width="1px">
   </td>
 </tr>
 '''
@@ -458,7 +458,7 @@ text
 '''
 
         expected = '''\
-<div style="font-size: 10pt">
+<div style="font-size: 10.0pt">
 text
 </div>
 '''
@@ -478,8 +478,8 @@ text
 
 
         expected = '''\
-<div style="font-size: 15pt">
-  <div style="font-size: 15pt">
+<div style="font-size: 15.0pt">
+  <div style="font-size: 15.0pt">
     text
   </div>
 </div>'''
@@ -497,7 +497,7 @@ text
 '''
 
         expected = '''\
-<div style="font-size: 1pt">
+<div style="font-size: 1.0pt">
 text
 </div>
 '''
@@ -516,7 +516,7 @@ text
 '''
 
         expected = '''\
-<div style="font-size: 1pt">
+<div style="font-size: 1.0pt">
 text
 </div>
 '''
@@ -537,7 +537,7 @@ text
 
 
         expected = '''\
-<div style="font-size: 15pt">
+<div style="font-size: 15.0pt">
   <div style="font-size: 22.5pt">
     text
   </div>
@@ -561,7 +561,7 @@ text
 
 
         expected = '''\
-<div style="font-size: 15pt">
+<div style="font-size: 15.0pt">
   <div style="font-size: 22.5pt">
     text
     <div style="font-size: 22.5pt">


### PR DESCRIPTION
I don't know if you had a chance to run the preprocessing step with the new cssless QCH preprocessor yet, but I can tell you it's incredibly slow (like, hours for the complete site on my Intel Core i5-7200U laptop). I tried to improve the performance of that, however, my changes might be somewhat controversial.

I profiled the cssless preprocessing script and noticed that most of the execution time was spent parsing CSS and dumping it to text again and again. So I decided to see whether this could be done using regular expressions instead, since the CSS used on the site is not too complicated. Turns out this works just fine, cutting the execution time of the unit tests in half.

A lot of the CSS parsing happens in premailer, not in our preprocessing script. So the second step I took was to include the premailer source code into the project (premailer hasn't been seriously maintained in several years), so we could modify it. I did the same thing again, using regular expressions instead of full CSS parsing where possible. This again worked great, the execution times for unit tests (which include full preprocessing of two files) is now down to about 1.4s from over 7s at the beginning.

Now the thing that might be controversial is that of course this could break at any time if the site started using CSS that is more complex than a simple regex can handle. I don't see that happening, but feel free to reject this PR if you're concerned about that.