### PR TITLE
Preprocess: remove duplicate preprocessing

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -54,9 +54,6 @@ def main():
             if len(output) > 0:
                 print(output)
 
-    for fn in preprocess.find_html_files(root):
-        preprocess.preprocess_html_file(root, fn, rename_map)
-
     # append css modifications
     with open(os.path.join(root, 'common/site_modules.css'), "a") as out:
         with open("preprocess-css.css", "r") as pp:


### PR DESCRIPTION
This removes duplicate preprocessing of all HTML files left over from the conversion to concurrent preprocessing.