### PR TITLE
Remove dead loader link

### DIFF
--- a/commands/preprocess.py
+++ b/commands/preprocess.py
@@ -355,3 +355,12 @@ def preprocess_css_file(fn):
     f = open(fn, "w", encoding='utf-8')
     f.write(text)
     f.close()
+
+def preprocess_startup_script(fn):
+    with open(fn, "r", encoding='utf-8') as f:
+        text = f.read()
+
+    text = re.sub(r'document\.write\([^)]+\);', '', text)
+
+    with open(fn, "w", encoding='utf-8') as f:
+        f.write(text)

--- a/preprocess.py
+++ b/preprocess.py
@@ -65,5 +65,7 @@ def main():
                 os.path.join(root, 'common/ext.css') ]:
         preprocess.preprocess_css_file(fn)
 
+    preprocess.preprocess_startup_script(os.path.join(root, 'common/startup_scripts.js'))
+
 if __name__ == "__main__":
     main()

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -260,7 +260,7 @@ class TestPreprocessHtml(unittest.TestCase):
         remove_fileinfo(self.html)
         self.check_output("fabs_fileinfo.html")
 
-    def remove_unused_external(self):
+    def test_remove_unused_external(self):
         remove_unused_external(self.html)
         self.check_output("fabs_external.html")
 


### PR DESCRIPTION
This adds a preprocessing step to the startup script to remove a dead loader link that is inserted by the script. Also I messed up the name of the test function for `remove_unused_external` earlier, fixed as well.