### PR TITLE
Headers: Fix structured bindings with libclang

### DIFF
--- a/headers/tuple
+++ b/headers/tuple
@@ -89,7 +89,7 @@ public:
 };
 
 template<class... Types >
-class tuple_size<std::tuple<Types...> > : public std::integral_constant<std::size_t, sizeof...(Types)> { };
+struct tuple_size<std::tuple<Types...> > : std::integral_constant<std::size_t, sizeof...(Types)> { };
 
 template<std::size_t I, class... Types >
 class tuple_element<I, tuple<Types...> > {

--- a/headers/tuple
+++ b/headers/tuple
@@ -92,7 +92,7 @@ template<class... Types >
 struct tuple_size<std::tuple<Types...> > : std::integral_constant<std::size_t, sizeof...(Types)> { };
 
 template<std::size_t I, class... Types >
-class tuple_element<I, tuple<Types...> > {
+struct tuple_element<I, tuple<Types...> > {
     typedef void type;
 }; // SIMPLIFIED
 

--- a/headers/utility
+++ b/headers/utility
@@ -234,9 +234,27 @@ void swap(pair<T1, T2>& lhs, pair<T1, T2>& rhs);
 template<size_t N, class T>
 struct tuple_element;
 
+template<class T1, class T2>
+struct tuple_element<0, std::pair<T1, T2>> { using type = T1; };
+template<class T1, class T2>
+struct tuple_element<1, std::pair<T1, T2>> { using type = T2; };
+
 template<size_t N, class T1, class T2>
 typename tuple_element<N, std::pair<T1, T2>>::type&
         get(pair<T1, T2>& p);
+
+template<size_t N, class T1, class T2>
+const typename tuple_element<N, std::pair<T1, T2>>::type&
+        get(const pair<T1, T2>& p);
+
+template<size_t N, class T1, class T2>
+typename tuple_element<N, std::pair<T1, T2>>::type&&
+        get(pair<T1, T2>&& p);
+
+template<size_t N, class T1, class T2>
+const typename tuple_element<N, std::pair<T1, T2>>::type&&
+        get(const pair<T1, T2>&& p);
+
 // SIMPLIFIED: additional overloads omitted
 #endif
 

--- a/headers/utility
+++ b/headers/utility
@@ -232,7 +232,7 @@ void swap(pair<T1, T2>& lhs, pair<T1, T2>& rhs);
 
 #if CPPREFERENCE_STDVER>= 2011
 template<size_t N, class T>
-class tuple_element;
+struct tuple_element;
 
 template<size_t N, class T1, class T2>
 typename tuple_element<N, std::pair<T1, T2>>::type&


### PR DESCRIPTION
This PR adds enough functionality for structured bindings with std::pair to work with libclang-based IDEs.